### PR TITLE
remove datasets and chunks

### DIFF
--- a/R/get_merge_call.R
+++ b/R/get_merge_call.R
@@ -342,7 +342,7 @@ get_dropped_filters <- function(selector) {
 #' @return (`call`) to relabel `dataset` and assign to `anl_name`.
 #'
 #' @export
-get_anl_relabel_call <- function(columns_source, datasets, anl_name = "ANL") {
+get_anl_relabel_call <- function(columns_source, data, anl_name = "ANL") {
   logger::log_trace(
     paste(
       "get_anl_relabel_call called with:",
@@ -361,7 +361,10 @@ get_anl_relabel_call <- function(columns_source, datasets, anl_name = "ANL") {
         if (rlang::is_empty(column_names)) {
           return(NULL)
         }
-        column_labels <- datasets$get_varlabels(attr(selector, "dataname"), column_names)
+
+        data_used <- data[attr(selector, "dataname")]
+        labels <- formatters::var_labels(data[attr(selector, "dataname")][[1]], fill = FALSE)
+        column_labels <- labels[intersect(colnames(data_used), column_names)]
 
         # NULL for no labels at all, character(0) for no labels for a given columns
         return(


### PR DESCRIPTION
closes #61 

Dependency on `datasets` and `chunks` has been removed from data merge module is such a way:
1) New modules `merge_expression_module` and `merge_expression_srv` which are the new versions of `data_merge_module` and `data_merge_srv`. The new modules have `data` instead of `datasets` as argument and an additional argument `join_keys`.
2) `Merge_datasets` is modified to use `data` instead of `datasets` and chunks was completely removed from it. It now returns a list of `expr`, `columns_source`, `key` and `filter_info`. No `data` or `chunks` are returned anymore. Be aware that `expr` now is a list of calls instead of character.
3) `get_dplyr_call` and `get_merge_call` have been modified accordingly.
4) `data_merge_srv` has been modified in a way to use the same `merge_datasets`, `get_dplyr_call` and `get_merge_call` scripts. It defines `data` and `join_keys` internally and calls `merge_expression_srv` where it appends `data` and `chunks` to the returned list.

Please test with the example apps in `merge_expression_module.R` and `data_merge_module.R`. Note that we still need `datasets` so far as it is still used in `data_extract` until this is done https://github.com/insightsengineering/teal.transform/issues/67