### PR TITLE
Fix assertion and docs

### DIFF
--- a/R/data_merge_module.R
+++ b/R/data_merge_module.R
@@ -100,7 +100,7 @@ data_merge_module <- function(datasets,
                               id = "merge_id") {
   logger::log_trace("data_merge_module called with: { paste(datasets$datanames(), collapse = ', ') } datasets.")
 
-  checkmate::assert_list(data_extract, c("list", "data_extract_spec", "null"))
+  checkmate::assert_list(data_extract, c("list", "data_extract_spec", "NULL"))
   lapply(data_extract, function(x) {
     if (is.list(x) && !inherits(x, "data_extract_spec")) {
       checkmate::assert_list(x, "data_extract_spec")

--- a/R/data_merge_module.R
+++ b/R/data_merge_module.R
@@ -100,7 +100,7 @@ data_merge_module <- function(datasets,
                               id = "merge_id") {
   logger::log_trace("data_merge_module called with: { paste(datasets$datanames(), collapse = ', ') } datasets.")
 
-  checkmate::assert_list(data_extract, c("list", "data_extract_spec"))
+  checkmate::assert_list(data_extract, c("list", "data_extract_spec"), null.ok = TRUE)
   lapply(data_extract, function(x) {
     if (is.list(x) && !inherits(x, "data_extract_spec")) {
       checkmate::assert_list(x, "data_extract_spec")

--- a/R/data_merge_module.R
+++ b/R/data_merge_module.R
@@ -100,7 +100,7 @@ data_merge_module <- function(datasets,
                               id = "merge_id") {
   logger::log_trace("data_merge_module called with: { paste(datasets$datanames(), collapse = ', ') } datasets.")
 
-  checkmate::assert_list(data_extract, c("list", "data_extract_spec"), null.ok = TRUE)
+  checkmate::assert_list(data_extract, c("list", "data_extract_spec", "null"))
   lapply(data_extract, function(x) {
     if (is.list(x) && !inherits(x, "data_extract_spec")) {
       checkmate::assert_list(x, "data_extract_spec")

--- a/R/merge_datasets.R
+++ b/R/merge_datasets.R
@@ -9,7 +9,7 @@
 #' @inheritParams merge_expression_srv
 #' @return merged_dataset (`list`) containing:
 #' - `expr` (`list` of `call`) code needed to replicate merged dataset.
-#' - `columns_source`` (`list`) of column names selected for particular selector.
+#' - `columns_source` (`list`) of column names selected for particular selector.
 #'   Each list element contains named character vector where:
 #'   * Values are the names of the columns in the ANL. In case if the same column name is selected in more than one
 #'     selector it gets prefixed by the id of the selector. For example if two `data_extract` have id `x`, `y`, then
@@ -17,8 +17,8 @@
 #'   * Names of the vector denote names of the variables in the input dataset.
 #'   * `attr(,"dataname")` to indicate which dataset variable is merged from.
 #'   * `attr(, "always selected")` to denote the names of the variables which need to be always selected.
-#' - `keys`` (`list`) the keys of the merged dataset.
-#' - `filter_info`` (`list`) The information given by the user. This information
+#' - `keys` (`list`) the keys of the merged dataset.
+#' - `filter_info` (`list`) The information given by the user. This information
 #'    defines the filters that are applied on the data. Additionally it defines
 #'    the variables that are selected from the data sets.
 #' @export

--- a/R/merge_datasets.R
+++ b/R/merge_datasets.R
@@ -8,14 +8,19 @@
 #'
 #' @inheritParams merge_expression_srv
 #' @return merged_dataset (`list`) containing:
-#' \itemize{
-#'  \item `expr` (`list` of `call`) code needed to replicate merged dataset.
-#'  \item columns_source (`list`) of column selected for particular selector.
-#'  \item keys (`list`) the keys of the merged dataset.
-#'  \item filter_info (`list`) The information given by the user. This information
+#' - `expr` (`list` of `call`) code needed to replicate merged dataset.
+#' - `columns_source`` (`list`) of column names selected for particular selector.
+#'   Each list element contains named character vector where:
+#'   * Values are the names of the columns in the ANL. In case if the same column name is selected in more than one
+#'     selector it gets prefixed by the id of the selector. For example if two `data_extract` have id `x`, `y`, then
+#'     their duplicated selected variable (for example `AGE`) is prefixed to be `x.AGE` and `y.AGE`.
+#'   * Names of the vector denote names of the variables in the input dataset.
+#'   * `attr(,"dataname")` to indicate which dataset variable is merged from.
+#'   * `attr(, "always selected")` to denote the names of the variables which need to be always selected.
+#' - `keys`` (`list`) the keys of the merged dataset.
+#' - `filter_info`` (`list`) The information given by the user. This information
 #'    defines the filters that are applied on the data. Additionally it defines
 #'    the variables that are selected from the data sets.
-#' }
 #' @export
 #'
 #' @examples

--- a/R/merge_datasets.R
+++ b/R/merge_datasets.R
@@ -11,7 +11,7 @@
 #' - `expr` (`list` of `call`) code needed to replicate merged dataset.
 #' - `columns_source` (`list`) of column names selected for particular selector.
 #'   Each list element contains named character vector where:
-#'   * Values are the names of the columns in the ANL. In case if the same column name is selected in more than one
+#'   * Values are the names of the columns in the `ANL`. In case if the same column name is selected in more than one
 #'     selector it gets prefixed by the id of the selector. For example if two `data_extract` have id `x`, `y`, then
 #'     their duplicated selected variable (for example `AGE`) is prefixed to be `x.AGE` and `y.AGE`.
 #'   * Names of the vector denote names of the variables in the input dataset.

--- a/R/merge_expression_module.R
+++ b/R/merge_expression_module.R
@@ -141,8 +141,7 @@ merge_expression_module <- function(datasets,
                                     anl_name = "ANL",
                                     id = "merge_id") {
   logger::log_trace("merge_expression_module called with: { paste(names(datasets), collapse = ', ') } datasets.")
-
-  checkmate::assert_list(data_extract, names = "named", types = c("list", "data_extract_spec"))
+  checkmate::assert_list(data_extract, names = "named", types = c("list", "data_extract_spec"), null.ok = TRUE)
   lapply(data_extract, function(x) {
     if (is.list(x) && !inherits(x, "data_extract_spec")) {
       checkmate::assert_list(x, "data_extract_spec")

--- a/R/merge_expression_module.R
+++ b/R/merge_expression_module.R
@@ -141,7 +141,7 @@ merge_expression_module <- function(datasets,
                                     anl_name = "ANL",
                                     id = "merge_id") {
   logger::log_trace("merge_expression_module called with: { paste(names(datasets), collapse = ', ') } datasets.")
-  checkmate::assert_list(data_extract, names = "named", types = c("list", "data_extract_spec"), null.ok = TRUE)
+  checkmate::assert_list(data_extract, names = "named", types = c("list", "data_extract_spec", "null"))
   lapply(data_extract, function(x) {
     if (is.list(x) && !inherits(x, "data_extract_spec")) {
       checkmate::assert_list(x, "data_extract_spec")

--- a/R/merge_expression_module.R
+++ b/R/merge_expression_module.R
@@ -141,7 +141,7 @@ merge_expression_module <- function(datasets,
                                     anl_name = "ANL",
                                     id = "merge_id") {
   logger::log_trace("merge_expression_module called with: { paste(names(datasets), collapse = ', ') } datasets.")
-  checkmate::assert_list(data_extract, names = "named", types = c("list", "data_extract_spec", "null"))
+  checkmate::assert_list(data_extract, names = "named", types = c("list", "data_extract_spec", "NULL"))
   lapply(data_extract, function(x) {
     if (is.list(x) && !inherits(x, "data_extract_spec")) {
       checkmate::assert_list(x, "data_extract_spec")

--- a/man/merge_datasets.Rd
+++ b/man/merge_datasets.Rd
@@ -39,7 +39,7 @@ merged_dataset (\code{list}) containing:
 \item \code{columns_source} (\code{list}) of column names selected for particular selector.
 Each list element contains named character vector where:
 \itemize{
-\item Values are the names of the columns in the ANL. In case if the same column name is selected in more than one
+\item Values are the names of the columns in the \code{ANL}. In case if the same column name is selected in more than one
 selector it gets prefixed by the id of the selector. For example if two \code{data_extract} have id \code{x}, \code{y}, then
 their duplicated selected variable (for example \code{AGE}) is prefixed to be \code{x.AGE} and \code{y.AGE}.
 \item Names of the vector denote names of the variables in the input dataset.

--- a/man/merge_datasets.Rd
+++ b/man/merge_datasets.Rd
@@ -36,9 +36,18 @@ Name of the analysis dataset.}
 merged_dataset (\code{list}) containing:
 \itemize{
 \item \code{expr} (\code{list} of \code{call}) code needed to replicate merged dataset.
-\item columns_source (\code{list}) of column selected for particular selector.
-\item keys (\code{list}) the keys of the merged dataset.
-\item filter_info (\code{list}) The information given by the user. This information
+\item \verb{columns_source`` (}list`) of column names selected for particular selector.
+Each list element contains named character vector where:
+\itemize{
+\item Values are the names of the columns in the ANL. In case if the same column name is selected in more than one
+selector it gets prefixed by the id of the selector. For example if two \code{data_extract} have id \code{x}, \code{y}, then
+their duplicated selected variable (for example \code{AGE}) is prefixed to be \code{x.AGE} and \code{y.AGE}.
+\item Names of the vector denote names of the variables in the input dataset.
+\item \code{attr(,"dataname")} to indicate which dataset variable is merged from.
+\item \code{attr(, "always selected")} to denote the names of the variables which need to be always selected.
+}
+\item \verb{keys`` (}list`) the keys of the merged dataset.
+\item \verb{filter_info`` (}list`) The information given by the user. This information
 defines the filters that are applied on the data. Additionally it defines
 the variables that are selected from the data sets.
 }

--- a/man/merge_datasets.Rd
+++ b/man/merge_datasets.Rd
@@ -36,7 +36,7 @@ Name of the analysis dataset.}
 merged_dataset (\code{list}) containing:
 \itemize{
 \item \code{expr} (\code{list} of \code{call}) code needed to replicate merged dataset.
-\item \verb{columns_source`` (}list`) of column names selected for particular selector.
+\item \code{columns_source} (\code{list}) of column names selected for particular selector.
 Each list element contains named character vector where:
 \itemize{
 \item Values are the names of the columns in the ANL. In case if the same column name is selected in more than one
@@ -46,8 +46,8 @@ their duplicated selected variable (for example \code{AGE}) is prefixed to be \c
 \item \code{attr(,"dataname")} to indicate which dataset variable is merged from.
 \item \code{attr(, "always selected")} to denote the names of the variables which need to be always selected.
 }
-\item \verb{keys`` (}list`) the keys of the merged dataset.
-\item \verb{filter_info`` (}list`) The information given by the user. This information
+\item \code{keys} (\code{list}) the keys of the merged dataset.
+\item \code{filter_info} (\code{list}) The information given by the user. This information
 defines the filters that are applied on the data. Additionally it defines
 the variables that are selected from the data sets.
 }

--- a/tests/testthat/test-merge_expression_module.R
+++ b/tests/testthat/test-merge_expression_module.R
@@ -80,7 +80,10 @@ testthat::test_that("merge_expression_module throws error if data_extract is not
         )
       }
     ),
-    "May only contain the following types: {list,data_extract_spec}, but element 2 has type 'character'",
+    paste0(
+      "Assertion on 'data_extract' failed: ",
+      "May only contain the following types: {list,data_extract_spec,null}, but element 2 has type 'character'."
+    ),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-merge_expression_module.R
+++ b/tests/testthat/test-merge_expression_module.R
@@ -82,7 +82,7 @@ testthat::test_that("merge_expression_module throws error if data_extract is not
     ),
     paste0(
       "Assertion on 'data_extract' failed: ",
-      "May only contain the following types: {list,data_extract_spec,null}, but element 2 has type 'character'."
+      "May only contain the following types: {list,data_extract_spec,NULL}, but element 2 has type 'character'."
     ),
     fixed = TRUE
   )

--- a/tests/testthat/test-merge_expression_module.R
+++ b/tests/testthat/test-merge_expression_module.R
@@ -68,6 +68,21 @@ testthat::test_that("merge_expression_module returns a reactive containing a lis
   )
 })
 
+testthat::test_that("merge_expression_module works if list some elements of the list are  NULL", {
+  testthat::expect_silent(
+    shiny::withReactiveDomain(
+      domain = shiny::MockShinySession$new(),
+      expr = {
+        merge_expression_module(
+          data_extract = list(adsl_var = adsl_extract, adlb_var = NULL),
+          datasets = data_list,
+          join_keys = join_keys
+        )
+      }
+    )
+  )
+})
+
 testthat::test_that("merge_expression_module throws error if data_extract is not a list of data_extract_spec", {
   testthat::expect_error(
     shiny::withReactiveDomain(


### PR DESCRIPTION
closes https://github.com/insightsengineering/teal.modules.clinical/issues/568
fix
- list of data extract spec can be NULL also because data_extract_multiple handles this situation by not processing this item
https://github.com/insightsengineering/teal.transform/blob/8bff27130125046ca95915c1bb07c303449f0b55/R/data_extract_module.R#L619

SO the data_merge_module, merge_expression_module, data_extract_multiple_srv can accept empty list element

Branch is 26_new_chunks@main but the change qualifies to main