### PR TITLE
use checkmate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: teal.transform
 Title: Functions for Extracting and Merging Data in the `teal` Framework
-Version: 0.1.1.9017
-Date: 2022-10-05
+Version: 0.2.0
+Date: 2022-10-14
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),
     person("Pawel", "Rucki", , "pawel.rucki@roche.com", role = "aut"),
@@ -29,18 +29,18 @@ Imports:
     shiny,
     shinyjs,
     stats,
-    teal.code (>= 0.1.1),
-    teal.data (>= 0.1.1),
-    teal.logger (>= 0.1.0),
-    teal.slice (>= 0.1.1),
-    teal.widgets (>= 0.1.1),
+    teal.code (>= 0.2.0),
+    teal.data (>= 0.1.2),
+    teal.logger (>= 0.1.1),
+    teal.slice (>= 0.2.0),
+    teal.widgets (>= 0.2.0),
     tidyr,
     tidyselect
 Suggests:
     knitr,
     rmarkdown,
-    scda (>= 0.1.3),
-    scda.2021 (>= 0.1.3),
+    scda (>= 0.1.5),
+    scda.2021 (>= 0.1.5),
     shinytest,
     testthat (>= 2.0)
 VignetteBuilder:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: teal.transform
 Title: Functions for Extracting and Merging Data in the `teal` Framework
-Version: 0.2.0
+Version: 0.2.0.9000
 Date: 2022-10-14
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# teal.transform 0.2.0.9000
+
 # teal.transform 0.2.0
 
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # teal.transform 0.2.0.9000
 
+### Enhancements
+
+* Updated error messages for `choices_labeled()`, `variable_choices()` and `value_choices()` to be more informative.
+
 # teal.transform 0.2.0
 
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.transform 0.1.1.9017
+# teal.transform 0.2.0
 
 ### Breaking changes
 

--- a/R/choices_labeled.R
+++ b/R/choices_labeled.R
@@ -4,14 +4,14 @@
 #' This is often useful for [choices_selected] as it marks up the dropdown boxes
 #' for [shiny::selectInput()].
 #'
-#' @param choices a character / numeric / logical vector
+#' @param choices A character / factor / numeric / logical vector of length > 1.
 #' @param labels character vector containing labels to be applied to `choices`. If `NA` then
 #' "Label Missing" will be used.
 #' @param subset a vector that is a subset of `choices`. This is useful if
 #'   only a few variables need to be named. If this argument is used, the returned vector will
 #'   match its order.
-#' @param types vector containing the types of the columns to be used for applying the appropriate
-#'   icons to the [choices_selected] drop down box
+#' @param types Character vector containing the types of the columns to be used for applying the appropriate
+#'   icons to the [choices_selected] drop down box. (e.g. "numeric")
 #' @details If either `choices` or `labels` are factors, they are coerced to character.
 #' Duplicated elements from `choices` get removed.
 #'

--- a/R/choices_labeled.R
+++ b/R/choices_labeled.R
@@ -61,10 +61,10 @@ choices_labeled <- function(choices, labels, subset = NULL, types = NULL) {
   }
 
   checkmate::assert(
-    checkmate::check_numeric(choices),
-    checkmate::check_character(choices),
-    checkmate::check_logical(choices),
-    checkmate::check_true(length(choices) == 1 && is.na(choices))
+    checkmate::check_character(choices, min.len = 2, any.missing = FALSE),
+    checkmate::check_factor(choices, min.len = 2, any.missing = FALSE),
+    checkmate::check_numeric(choices, min.len = 2, any.missing = FALSE),
+    checkmate::check_logical(choices, min.len = 2, any.missing = FALSE)
   )
 
   if (is.factor(labels)) {
@@ -75,12 +75,8 @@ choices_labeled <- function(choices, labels, subset = NULL, types = NULL) {
   if (length(choices) != length(labels)) {
     stop("length of choices must be the same as labels")
   }
-  checkmate::assert_vector(subset, null.ok = TRUE)
-  checkmate::assert_vector(types, null.ok = TRUE)
-
-  if (is.vector(types)) {
-    checkmate::assert_true(length(choices) == length(types))
-  }
+  checkmate::assert_subset(subset, choices, empty.ok = TRUE)
+  checkmate::assert_character(types, len = length(choices), null.ok = TRUE)
 
   if (!is.null(subset)) {
     if (!all(subset %in% choices)) {
@@ -201,14 +197,20 @@ variable_choices.character <- function(data, subset = NULL, fill = FALSE, key = 
 #' @export
 variable_choices.data.frame <- function(data, subset = NULL, fill = TRUE, key = NULL) { # nolint
 
+  checkmate::assert(
+    checkmate::check_character(subset, null.ok = TRUE),
+    checkmate::check_function(subset, null.ok = TRUE)
+  )
+
   if (is.function(subset)) {
     subset <- resolve_delayed_expr(subset, ds = data, is_value_choices = FALSE)
   }
 
+  checkmate::assert_subset(subset, c("", names(data)), empty.ok = TRUE)
+
   if (length(subset) == 0) {
     subset <- names(data)
   }
-  checkmate::assert_subset(subset, c("", names(data)))
 
   key <- intersect(subset, key)
 
@@ -363,7 +365,7 @@ value_choices.data.frame <- function(data, # nolint
                                      subset = NULL,
                                      sep = " - ") {
   checkmate::assert_subset(var_choices, names(data))
-  checkmate::assert_subset(var_label, names(data))
+  checkmate::assert_subset(var_label, names(data), empty.ok = TRUE)
 
   df_choices <- data[var_choices]
   df_label <- data[var_label]

--- a/R/choices_labeled.R
+++ b/R/choices_labeled.R
@@ -342,14 +342,15 @@ value_choices.character <- function(data,
                                     var_label = NULL,
                                     subset = NULL,
                                     sep = " - ") {
-  out <- structure(list(
-    data = data,
-    var_choices = var_choices,
-    var_label = var_label,
-    subset = subset,
-    sep = sep
-  ),
-  class = c("delayed_value_choices", "delayed_data", "choices_labeled")
+  out <- structure(
+    list(
+      data = data,
+      var_choices = var_choices,
+      var_label = var_label,
+      subset = subset,
+      sep = sep
+    ),
+    class = c("delayed_value_choices", "delayed_data", "choices_labeled")
   )
   return(out)
 }

--- a/man/choices_labeled.Rd
+++ b/man/choices_labeled.Rd
@@ -10,7 +10,7 @@ choices_labeled(choices, labels, subset = NULL, types = NULL)
 \method{print}{choices_labeled}(x, ...)
 }
 \arguments{
-\item{choices}{a character / numeric / logical vector}
+\item{choices}{A character / factor / numeric / logical vector of length > 1.}
 
 \item{labels}{character vector containing labels to be applied to \code{choices}. If \code{NA} then
 "Label Missing" will be used.}
@@ -19,8 +19,8 @@ choices_labeled(choices, labels, subset = NULL, types = NULL)
 only a few variables need to be named. If this argument is used, the returned vector will
 match its order.}
 
-\item{types}{vector containing the types of the columns to be used for applying the appropriate
-icons to the \link{choices_selected} drop down box}
+\item{types}{Character vector containing the types of the columns to be used for applying the appropriate
+icons to the \link{choices_selected} drop down box. (e.g. "numeric")}
 
 \item{x}{an object used to select a method.}
 


### PR DESCRIPTION
closes #99 

Update all the `stopifnot` statements in `choices.labeled.R` to use `checkmate` so that the error messages are meaningful and that we have a unified way of checking.

Test with example:
```
dd <- data.frame(A = c(1,2,3), B = c("A", "B", "C"))
variable_choices(dd, subset = c("D"))
```

All tests pass so I assume the logic is still respected.