### PR TITLE
Add tests for data extract input validation

### DIFF
--- a/tests/testthat/test-data_extract_srv.R
+++ b/tests/testthat/test-data_extract_srv.R
@@ -504,30 +504,30 @@ testthat::test_that("select validation accepts function as validator", {
 
 })
 
-iris_select <- data_extract_spec(
-  dataname = "iris",
-  select = select_spec(
-    label = "Select variable:",
-    choices = variable_choices(iris, colnames(iris)),
-    selected = "Sepal.Length",
-    multiple = TRUE,
-    fixed = FALSE
-  )
-)
-
-iris_filter <- data_extract_spec(
-  dataname = "iris",
-  filter = filter_spec(
-    vars = "Species",
-    choices = c("setosa", "versicolor", "virginica"),
-    selected = "setosa",
-    multiple = TRUE
-  )
-)
-
-data_list <- list(iris = reactive(iris))
-
 testthat::test_that("data_extract_multiple_srv input validation", {
+
+  iris_select <- data_extract_spec(
+    dataname = "iris",
+    select = select_spec(
+      label = "Select variable:",
+      choices = variable_choices(iris, colnames(iris)),
+      selected = "Sepal.Length",
+      multiple = TRUE,
+      fixed = FALSE
+    )
+  )
+
+  iris_filter <- data_extract_spec(
+    dataname = "iris",
+    filter = filter_spec(
+      vars = "Species",
+      choices = c("setosa", "versicolor", "virginica"),
+      selected = "setosa",
+      multiple = TRUE
+    )
+  )
+
+  data_list <- list(iris = reactive(iris))
 
   server = function(input, output, session) {
     exactly_2_validation <- function(msg) {

--- a/tests/testthat/test-data_extract_srv.R
+++ b/tests/testthat/test-data_extract_srv.R
@@ -260,7 +260,6 @@ testthat::test_that("data_extract_srv throws error with wrong argument input typ
     ),
     regexp = "Assertion on 'select_validation_rule' failed:"
   )
-
 })
 
 testthat::test_that("data_extract_srv uses the current session id when id is missing", {
@@ -386,9 +385,7 @@ data_list_val <- list(ADSL = reactive(ADSL_val))
 join_keys_val <- teal.data::join_keys(teal.data::join_key("ADSL", "ADSL", c("STUDYID", "USUBJID")))
 
 testthat::test_that("select validation", {
-
   server <- function(input, output, session) {
-
     adsl_reactive_input <- data_extract_srv(
       id = "adsl_var",
       datasets = data_list_val,
@@ -421,14 +418,11 @@ testthat::test_that("select validation", {
     session$setInputs("adsl_var-dataset_ADSL_singleextract-select" = "")
     expect_match(output$out1, "Please fix errors in your selection")
   })
-
 })
 
 
 testthat::test_that("filter validation", {
-
   server <- function(input, output, session) {
-
     adsl_reactive_input <- data_extract_srv(
       id = "adsl_var",
       datasets = data_list_val,
@@ -461,14 +455,11 @@ testthat::test_that("filter validation", {
     session$setInputs("adsl_var-dataset_ADSL_singleextract-filter1-vals" = "")
     expect_match(output$out1, "Please fix errors in your selection")
   })
-
 })
 
 
 testthat::test_that("select validation accepts function as validator", {
-
   server <- function(input, output, session) {
-
     adsl_reactive_input <- data_extract_srv(
       id = "adsl_var",
       datasets = data_list_val,
@@ -501,11 +492,9 @@ testthat::test_that("select validation accepts function as validator", {
     session$setInputs("adsl_var-dataset_ADSL_singleextract-select" = "")
     expect_match(output$out1, "Please fix errors in your selection")
   })
-
 })
 
 testthat::test_that("data_extract_multiple_srv input validation", {
-
   iris_select <- data_extract_spec(
     dataname = "iris",
     select = select_spec(
@@ -529,7 +518,7 @@ testthat::test_that("data_extract_multiple_srv input validation", {
 
   data_list <- list(iris = reactive(iris))
 
-  server = function(input, output, session) {
+  server <- function(input, output, session) {
     exactly_2_validation <- function(msg) {
       ~ if (length(.) != 2) msg
     }
@@ -579,7 +568,7 @@ testthat::test_that("data_extract_multiple_srv input validation", {
     expect_true(iv_r()$is_valid())
 
     out1 <- paste(output$out1, collapse = "")
-    msg <-       paste(
+    msg <- paste(
       lapply(
         selector_list(),
         function(x) format_data_extract(x())
@@ -610,9 +599,5 @@ testthat::test_that("data_extract_multiple_srv input validation", {
       "species_var-dataset_iris_singleextract-filter1-vals" = c("setosa", "versicolor")
     )
     expect_true(iv_r()$is_valid())
-
   })
-
 })
-
-

--- a/tests/testthat/test-data_extract_srv.R
+++ b/tests/testthat/test-data_extract_srv.R
@@ -185,6 +185,82 @@ testthat::test_that("data_extract_srv throws error with wrong argument input typ
     ),
     regexp = "Assertion on 'datasets' failed:"
   )
+
+  testthat::expect_error(
+    shiny::testServer(
+      data_extract_srv,
+      args = list(
+        id = "adsl_extract",
+        data_extract_spec = adsl_extract,
+        datasets = nr_data_list,
+        join_keys = join_keys_list,
+        select_validation_rule = "string"
+      ),
+      expr = NULL
+    ),
+    regexp = "Assertion on 'select_validation_rule' failed:"
+  )
+
+  testthat::expect_error(
+    shiny::testServer(
+      data_extract_srv,
+      args = list(
+        id = "adsl_extract",
+        data_extract_spec = adsl_extract,
+        datasets = nr_data_list,
+        join_keys = join_keys_list,
+        filter_validation_rule = "string"
+      ),
+      expr = NULL
+    ),
+    regexp = "Assertion on 'filter_validation_rule' failed:"
+  )
+
+  testthat::expect_error(
+    shiny::testServer(
+      data_extract_srv,
+      args = list(
+        id = "adsl_extract",
+        data_extract_spec = adsl_extract,
+        datasets = nr_data_list,
+        join_keys = join_keys_list,
+        dataset_validation_rule = "string"
+      ),
+      expr = NULL
+    ),
+    regexp = "Assertion on 'dataset_validation_rule' failed:"
+  )
+
+  testthat::expect_error(
+    shiny::testServer(
+      data_extract_srv,
+      args = list(
+        id = "adsl_extract",
+        data_extract_spec = adsl_extract,
+        datasets = nr_data_list,
+        join_keys = join_keys_list,
+        select_validation_rule = TRUE
+      ),
+      expr = NULL
+    ),
+    regexp = "Assertion on 'select_validation_rule' failed:"
+  )
+
+  testthat::expect_error(
+    shiny::testServer(
+      data_extract_srv,
+      args = list(
+        id = "adsl_extract",
+        data_extract_spec = adsl_extract,
+        datasets = nr_data_list,
+        join_keys = join_keys_list,
+        select_validation_rule = 1
+      ),
+      expr = NULL
+    ),
+    regexp = "Assertion on 'select_validation_rule' failed:"
+  )
+
 })
 
 testthat::test_that("data_extract_srv uses the current session id when id is missing", {


### PR DESCRIPTION
Add tests for the `select/filter_validation_rule` arguments in `data_extract_srv` and `data_extract_multiple_srv`. I think I've covered everything but it's definitely possible I missed a case. I will note that I did think about checking the value of `iv_r()` to see if we get the right messages but I decided against that because 1) time constraint and 2) I feel like it's essentially testing `shinyvalidate` itself which we shouldn't do. We _could_ also do some UI tests but that's basically testing `shinyvalidate` as well.