### PR TITLE
update testthat dependency version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     scda (>= 0.1.5),
     scda.2022 (>= 0.1.3),
     shinytest,
-    testthat (>= 2.0)
+    testthat (>= 3.1.5)
 VignetteBuilder:
     knitr
 RdMacros:


### PR DESCRIPTION
Related with #122

`expect_no_error` is being used in our unit test and this is a new function from testthat 3.1.5
Therefore, I'm updating the version dependency in DESCRIPTION
