### PR TITLE
decouple scda followup

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -41,3 +41,4 @@ SECURITY.md
 ^templates$
 ^test_full_example$
 coverage.*
+data-raw/data.R

--- a/R/choices_labeled.R
+++ b/R/choices_labeled.R
@@ -22,8 +22,8 @@
 #' @examples
 #' library(shiny)
 #'
-#' ADSL <- rADSL
-#' ADTTE <- rADTTE
+#' ADSL <- teal.transform::rADSL
+#' ADTTE <- teal.transform::rADTTE
 #' choices1 <- choices_labeled(names(ADSL), formatters::var_labels(ADSL, fill = FALSE))
 #' choices2 <- choices_labeled(ADTTE$PARAMCD, ADTTE$PARAM)
 #' # if only a subset of variables are needed, use subset argument
@@ -140,7 +140,7 @@ choices_labeled <- function(choices, labels, subset = NULL, types = NULL) {
 #' @export
 #'
 #' @examples
-#' ADRS <- rADRS
+#' ADRS <- teal.transform::rADRS
 #' variable_choices(ADRS)
 #' variable_choices(ADRS, subset = c("PARAM", "PARAMCD"))
 #' variable_choices(ADRS, subset = c("", "PARAM", "PARAMCD"))
@@ -297,7 +297,7 @@ variable_choices.TealDatasetConnector <- function(data, # nolint
 #' @export
 #'
 #' @examples
-#' ADRS <- rADRS
+#' ADRS <- teal.transform::rADRS
 #' value_choices(ADRS, "PARAMCD", "PARAM", subset = c("BESRSPI", "INVET"))
 #' value_choices(ADRS, c("PARAMCD", "ARMCD"), c("PARAM", "ARM"))
 #' value_choices(ADRS, c("PARAMCD", "ARMCD"), c("PARAM", "ARM"),

--- a/R/choices_selected.R
+++ b/R/choices_selected.R
@@ -46,7 +46,7 @@ no_select_keyword <- "-- no selection --"
 #'   selected = "C"
 #' )
 #'
-#' ADSL <- rADSL
+#' ADSL <- teal.transform::rADSL
 #' choices_selected(variable_choices(ADSL), "SEX")
 #'
 #' # How to select nothing

--- a/R/data.R
+++ b/R/data.R
@@ -3,7 +3,7 @@
 #' @description Random adverse events
 #' @docType data
 #'
-#' @usage data(rADAE)
+#' @usage rADAE
 #'
 #' @keywords datasets internal
 #'
@@ -16,7 +16,7 @@
 #' @description Random lab analysis
 #' @docType data
 #'
-#' @usage data(rADLB)
+#' @usage rADLB
 #'
 #' @keywords datasets internal
 #'
@@ -29,7 +29,7 @@
 #' @description Random response
 #' @docType data
 #'
-#' @usage data(rADRS)
+#' @usage rADRS
 #'
 #' @keywords datasets internal
 #'
@@ -44,7 +44,7 @@
 #'
 #' @keywords datasets internal
 #'
-#' @usage data(rADSL)
+#' @usage rADSL
 #'
 #' @source internal
 #' @name rADSL
@@ -57,7 +57,7 @@
 #'
 #' @keywords datasets internal
 #'
-#' @usage data(rADTTE)
+#' @usage rADTTE
 #'
 #' @source internal
 #' @name rADTTE

--- a/R/data.R
+++ b/R/data.R
@@ -42,9 +42,9 @@
 #' @description Random patient listing
 #' @docType data
 #'
-#' @keywords datasets internal
-#'
 #' @usage rADSL
+#'
+#' @keywords datasets internal
 #'
 #' @source internal
 #' @name rADSL
@@ -55,9 +55,9 @@
 #' @description Random Time to Event Analysis Dataset
 #' @docType data
 #'
-#' @keywords datasets internal
-#'
 #' @usage rADTTE
+#'
+#' @keywords datasets internal
 #'
 #' @source internal
 #' @name rADTTE

--- a/R/filter_spec.R
+++ b/R/filter_spec.R
@@ -222,7 +222,7 @@ filter_spec <- function(vars,
 #'   vars_multiple = TRUE
 #' )
 #'
-#' ADRS <- rADRS
+#' ADRS <- teal.transform::rADRS
 #' teal.transform:::filter_spec_internal(
 #'   vars_choices = variable_choices(ADRS),
 #'   vars_selected = "PARAMCD",

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -10,7 +10,7 @@
 #' @return Resolved object.
 #'
 #' @examples
-#' ADSL <- rADSL
+#' ADSL <- teal.transform::rADSL
 #' attr(ADSL, "keys") <- teal.data::get_cdisc_keys("ADSL")
 #' data_list <- list(ADSL = shiny::reactive(ADSL))
 #' keys <- list(ADSL = attr(ADSL, "keys"))

--- a/R/resolve_delayed.R
+++ b/R/resolve_delayed.R
@@ -12,7 +12,7 @@
 #' @export
 #'
 #' @examples
-#' ADSL <- rADSL
+#' ADSL <- teal.transform::rADSL
 #' shiny::isolate({
 #'   ds <- teal.slice::init_filtered_data(
 #'     list(ADSL = list(

--- a/data-raw/data.R
+++ b/data-raw/data.R
@@ -1,0 +1,16 @@
+## code to prepare `data` for testing examples
+library(scda)
+rADAE <- synthetic_cdisc_data("latest")$adae # nolint
+usethis::use_data(rADAE)
+
+rADLB <- synthetic_cdisc_data("latest")$adlb # nolint
+usethis::use_data(rADLB)
+
+rADRS <- synthetic_cdisc_data("latest")$adrs # nolint
+usethis::use_data(rADRS)
+
+rADSL <- synthetic_cdisc_data("latest")$adsl # nolint
+usethis::use_data(rADSL)
+
+rADTTE <- synthetic_cdisc_data("latest")$adtte # nolint
+usethis::use_data(rADTTE)

--- a/man/choices_labeled.Rd
+++ b/man/choices_labeled.Rd
@@ -43,8 +43,8 @@ Duplicated elements from \code{choices} get removed.
 \examples{
 library(shiny)
 
-ADSL <- rADSL
-ADTTE <- rADTTE
+ADSL <- teal.transform::rADSL
+ADTTE <- teal.transform::rADTTE
 choices1 <- choices_labeled(names(ADSL), formatters::var_labels(ADSL, fill = FALSE))
 choices2 <- choices_labeled(ADTTE$PARAMCD, ADTTE$PARAM)
 # if only a subset of variables are needed, use subset argument

--- a/man/choices_selected.Rd
+++ b/man/choices_selected.Rd
@@ -65,7 +65,7 @@ choices_selected(
   selected = "C"
 )
 
-ADSL <- rADSL
+ADSL <- teal.transform::rADSL
 choices_selected(variable_choices(ADSL), "SEX")
 
 # How to select nothing

--- a/man/filter_spec_internal.Rd
+++ b/man/filter_spec_internal.Rd
@@ -135,7 +135,7 @@ teal.transform:::filter_spec_internal(
   vars_multiple = TRUE
 )
 
-ADRS <- rADRS
+ADRS <- teal.transform::rADRS
 teal.transform:::filter_spec_internal(
   vars_choices = variable_choices(ADRS),
   vars_selected = "PARAMCD",

--- a/man/rADAE.Rd
+++ b/man/rADAE.Rd
@@ -11,7 +11,7 @@ An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) w
 internal
 }
 \usage{
-data(rADAE)
+rADAE
 }
 \description{
 Random adverse events

--- a/man/rADLB.Rd
+++ b/man/rADLB.Rd
@@ -11,7 +11,7 @@ An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) w
 internal
 }
 \usage{
-data(rADLB)
+rADLB
 }
 \description{
 Random lab analysis

--- a/man/rADRS.Rd
+++ b/man/rADRS.Rd
@@ -11,7 +11,7 @@ An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) w
 internal
 }
 \usage{
-data(rADRS)
+rADRS
 }
 \description{
 Random response

--- a/man/rADSL.Rd
+++ b/man/rADSL.Rd
@@ -11,7 +11,7 @@ An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) w
 internal
 }
 \usage{
-data(rADSL)
+rADSL
 }
 \description{
 Random patient listing

--- a/man/rADTTE.Rd
+++ b/man/rADTTE.Rd
@@ -11,7 +11,7 @@ An object of class \code{tbl_df} (inherits from \code{tbl}, \code{data.frame}) w
 internal
 }
 \usage{
-data(rADTTE)
+rADTTE
 }
 \description{
 Random Time to Event Analysis Dataset

--- a/man/resolve.Rd
+++ b/man/resolve.Rd
@@ -21,7 +21,7 @@ Resolved object.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \examples{
-ADSL <- rADSL
+ADSL <- teal.transform::rADSL
 attr(ADSL, "keys") <- teal.data::get_cdisc_keys("ADSL")
 data_list <- list(ADSL = shiny::reactive(ADSL))
 keys <- list(ADSL = attr(ADSL, "keys"))

--- a/man/resolve_delayed.Rd
+++ b/man/resolve_delayed.Rd
@@ -21,7 +21,7 @@ Resolved object.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \examples{
-ADSL <- rADSL
+ADSL <- teal.transform::rADSL
 shiny::isolate({
   ds <- teal.slice::init_filtered_data(
     list(ADSL = list(

--- a/man/value_choices.Rd
+++ b/man/value_choices.Rd
@@ -43,7 +43,7 @@ named character vector or \code{delayed_data} object
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \examples{
-ADRS <- rADRS
+ADRS <- teal.transform::rADRS
 value_choices(ADRS, "PARAMCD", "PARAM", subset = c("BESRSPI", "INVET"))
 value_choices(ADRS, c("PARAMCD", "ARMCD"), c("PARAM", "ARM"))
 value_choices(ADRS, c("PARAMCD", "ARMCD"), c("PARAM", "ARM"),

--- a/man/variable_choices.Rd
+++ b/man/variable_choices.Rd
@@ -55,7 +55,7 @@ named character vector with additional attributes or \code{delayed_data} object
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \examples{
-ADRS <- rADRS
+ADRS <- teal.transform::rADRS
 variable_choices(ADRS)
 variable_choices(ADRS, subset = c("PARAM", "PARAMCD"))
 variable_choices(ADRS, subset = c("", "PARAM", "PARAMCD"))

--- a/tests/testthat/test-data_extract_module.R
+++ b/tests/testthat/test-data_extract_module.R
@@ -1,5 +1,5 @@
-ADLB <- rADLB # nolint
-ADTTE <- rADTTE # nolint
+ADLB <- teal.transform::rADLB # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 
 testthat::test_that("Single filter", {
   data_extract <- data_extract_spec(

--- a/tests/testthat/test-data_extract_spec.R
+++ b/tests/testthat/test-data_extract_spec.R
@@ -203,8 +203,8 @@ testthat::test_that("delayed data_extract_spec works", {
   testthat::expect_identical(expected_spec, mix3_res)
 })
 
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE))
 key_list <- list(ADSL = teal.data::get_cdisc_keys("ADSL"), ADTTE = teal.data::get_cdisc_keys("ADTTE"))
 

--- a/tests/testthat/test-delayed_data_extract.R
+++ b/tests/testthat/test-delayed_data_extract.R
@@ -1,7 +1,7 @@
 # Contains integration tests between delayed data loading objects and
 # the objects responsible for loading, pulling and filtering the data
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 data <- teal.data::cdisc_data(
   teal.data::cdisc_dataset("ADSL", ADSL),
   teal.data::cdisc_dataset("ADTTE", ADTTE)
@@ -42,7 +42,7 @@ get_continuous <- function(data) {
 
 testthat::test_that("Delayed data extract - single data connector with two scda dataset connectors", {
   ADSL <- teal.data::cdisc_dataset(dataname = "ADSL", x = rADSL) # nolint
-  ADAE <- teal.data::cdisc_dataset(dataname = "ADAE", x = rADAE) # nolint
+  ADAE <- teal.data::cdisc_dataset(dataname = "ADAE", x = teal.transform::rADAE) # nolint
   data <- teal.data::cdisc_data(ADSL, ADAE)
 
   x <- data_extract_spec(
@@ -93,7 +93,7 @@ testthat::test_that("Delayed data extract - single data connector with two scda 
 
 testthat::test_that("Delayed choices selected - single data connector with two scda dataset connectors", {
   ADSL <- teal.data::cdisc_dataset(dataname = "ADSL", x = rADSL) # nolint
-  ADAE <- teal.data::cdisc_dataset(dataname = "ADAE", x = rADAE) # nolint
+  ADAE <- teal.data::cdisc_dataset(dataname = "ADAE", x = teal.transform::rADAE) # nolint
 
   data <- teal.data::cdisc_data(ADSL, ADAE)
 
@@ -418,14 +418,14 @@ testthat::test_that("Delayed extract two filters - single data connector with tw
 testthat::test_that("Delayed extract - TealData with single dataset and multiple connectors", {
   ADSL <- teal.data::dataset( # nolint
     dataname = "ADSL",
-    rADSL,
+    teal.transform::rADSL,
     keys = teal.data::get_cdisc_keys("ADSL"),
-    code = "ADSL <- rADSL",
+    code = "ADSL <- teal.transform::rADSL",
     label = "ADSL"
   )
 
-  ADRS <- teal.data::cdisc_dataset(dataname = "ADRS", x = rADRS) # nolint
-  ADTTE <- teal.data::cdisc_dataset(dataname = "ADTTE", x = rADTTE) # nolint
+  ADRS <- teal.data::cdisc_dataset(dataname = "ADRS", x = teal.transform::rADRS) # nolint
+  ADTTE <- teal.data::cdisc_dataset(dataname = "ADTTE", x = teal.transform::rADTTE) # nolint
   data <- teal.data::cdisc_data(ADSL, ADRS, ADTTE)
 
   x <- data_extract_spec(
@@ -540,7 +540,7 @@ testthat::test_that("Delayed extract - TealData with single dataset and multiple
 # with resolve_delayed
 testthat::test_that("Delayed data extract - single data connector with two scda dataset connectors - resolve_delayed", {
   ADSL <- teal.data::cdisc_dataset(dataname = "ADSL", x = rADSL) # nolint
-  ADAE <- teal.data::cdisc_dataset(dataname = "ADAE", x = rADAE) # nolint
+  ADAE <- teal.data::cdisc_dataset(dataname = "ADAE", x = teal.transform::rADAE) # nolint
 
   data <- teal.data::cdisc_data(ADSL, ADAE)
 
@@ -587,7 +587,7 @@ testthat::test_that(
   desc = "Delayed choices selected - single data connector with two scda dataset connectors - resolve_delayed",
   code = {
     ADSL <- teal.data::cdisc_dataset(dataname = "ADSL", x = rADSL) # nolint
-    ADAE <- teal.data::cdisc_dataset(dataname = "ADAE", x = rADAE) # nolint
+    ADAE <- teal.data::cdisc_dataset(dataname = "ADAE", x = teal.transform::rADAE) # nolint
     data <- teal.data::cdisc_data(ADSL, ADAE)
 
     choices <- variable_choices("ADSL")
@@ -894,13 +894,13 @@ testthat::test_that(
 testthat::test_that("Delayed extract - TealData with single dataset and multiple connectors - resolve_delayed", {
   ADSL <- teal.data::dataset( # nolint
     dataname = "ADSL",
-    rADSL,
+    teal.transform::rADSL,
     keys = teal.data::get_cdisc_keys("ADSL"),
-    code = "ADSL <- rADSL",
+    code = "ADSL <- teal.transform::rADSL",
     label = "ADSL"
   )
-  ADRS <- teal.data::cdisc_dataset(dataname = "ADRS", x = rADRS) # nolint
-  ADTTE <- teal.data::cdisc_dataset(dataname = "ADTTE", x = rADTTE) # nolint
+  ADRS <- teal.data::cdisc_dataset(dataname = "ADRS", x = teal.transform::rADRS) # nolint
+  ADTTE <- teal.data::cdisc_dataset(dataname = "ADTTE", x = teal.transform::rADTTE) # nolint
   data <- teal.data::cdisc_data(ADSL, ADRS, ADTTE)
 
   x <- data_extract_spec(

--- a/tests/testthat/test-filter_spec.R
+++ b/tests/testthat/test-filter_spec.R
@@ -212,7 +212,7 @@ testthat::test_that("filter_spec_internal", {
 })
 
 testthat::test_that("filter_spec_internal contains dataname", {
-  ADSL <- rADSL # nolint
+  ADSL <- teal.transform::rADSL # nolint
 
   x_filter <- filter_spec_internal(
     vars_choices = variable_choices(ADSL)
@@ -289,8 +289,8 @@ testthat::test_that("delayed filter_spec works", {
 })
 
 
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE))
 key_list <- list(ADSL = teal.data::get_cdisc_keys("ADSL"), ADTTE = teal.data::get_cdisc_keys("ADTTE"))
@@ -554,8 +554,8 @@ testthat::test_that("delayed filter_spec works - resolve_delayed", {
   testthat::expect_identical(expected_spec, isolate(resolve_delayed(delayed, ds)))
 })
 
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 data <- teal.data::cdisc_data(
   teal.data::cdisc_dataset("ADSL", ADSL),
   teal.data::cdisc_dataset("ADTTE", ADTTE)

--- a/tests/testthat/test-resolve.R
+++ b/tests/testthat/test-resolve.R
@@ -1,5 +1,5 @@
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 
 arm_ref_comp <- list(
   ARMCD = list(

--- a/tests/testthat/test-resolve_delayed.R
+++ b/tests/testthat/test-resolve_delayed.R
@@ -1,5 +1,5 @@
-adsl <- rADSL # nolint
-adtte <- rADTTE # nolint
+adsl <- teal.transform::rADSL # nolint
+adtte <- teal.transform::rADTTE # nolint
 data <- teal.data::cdisc_data(
   teal.data::cdisc_dataset("ADSL", adsl),
   teal.data::cdisc_dataset("ADTTE", adtte)

--- a/tests/testthat/test-select_spec.R
+++ b/tests/testthat/test-select_spec.R
@@ -113,8 +113,8 @@ testthat::test_that("resolve select_spec works", {
   testthat::expect_identical(expected_spec, isolate(resolve(delayed_spec, datasets = data_list, keys = key_list)))
 })
 
-adsl <- rADSL # nolint
-adtte <- rADTTE # nolint
+adsl <- teal.transform::rADSL # nolint
+adtte <- teal.transform::rADTTE # nolint
 
 vc_hard <- variable_choices("ADSL", subset = c("STUDYID", "USUBJID"))
 vc_hard_exp <- structure(

--- a/tests/testthat/test-value_choices.R
+++ b/tests/testthat/test-value_choices.R
@@ -1,5 +1,5 @@
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 
 testthat::test_that("Will output warnings when value_choices applied on datasets with missing values and / or labels", {
   data <- data.frame(

--- a/tests/testthat/test-variable_choices.R
+++ b/tests/testthat/test-variable_choices.R
@@ -1,5 +1,5 @@
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 
 test_that("Can create variable_choices with datasets with no or missing labels", {
   example_data <- data.frame(USUBJID = 1:2, STUDYID = 1:1)

--- a/vignettes/data-extract-merge.Rmd
+++ b/vignettes/data-extract-merge.Rmd
@@ -122,8 +122,8 @@ where a list of necessary join keys per `data.frame` object is required:
 
 ```{r}
 # Define data.frame objects
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 
 # create a list of data.frame objects
 datasets <- list(ADSL = ADSL, ADTTE = ADTTE)

--- a/vignettes/data-extract.Rmd
+++ b/vignettes/data-extract.Rmd
@@ -73,8 +73,8 @@ where a list of necessary join keys per `data.frame` object is required:
 
 ```{r}
 # Define data.frame objects
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 
 # create a list of data.frame objects
 datasets <- list(ADSL = ADSL, ADTTE = ADTTE)

--- a/vignettes/data-merge.Rmd
+++ b/vignettes/data-merge.Rmd
@@ -100,8 +100,8 @@ merge_module <- function(id, datasets, data_extracts, join_keys) {
 }
 
 # Define data.frame objects
-ADSL <- rADSL # nolint
-ADTTE <- rADTTE # nolint
+ADSL <- teal.transform::rADSL # nolint
+ADTTE <- teal.transform::rADTTE # nolint
 
 # create a list of data.frame objects
 datasets <- list(ADSL = ADSL, ADTTE = ADTTE)


### PR DESCRIPTION
A follow-up after #139 that closed #133 

After I had a chance to do a scda decoupling for goshawk https://github.com/insightsengineering/goshawk/pull/198 and had a chance to review scda decoupling for teal.modules.general https://github.com/insightsengineering/teal.modules.general/pull/534
I realized some changes need to be applied in PRs that were already merged in other packages.

Main changes:
- I prepend dataset names with package names as now we are having the same data in multiple packages (`teal.transform::rADAE` and `teal.modules.general::rADAE` for example)
- added a `data-raw/data.R` file to show how the `data/` folder was created
- extended `.RBuildignore` file to omit `data-raw/data.R` while building the package