### PR TITLE
77 deprecate data_merge_module and data_merge_srv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 ### Miscellaneous
 
 * Removed `scda` package dependency from examples.
+* Deprecated `data_merge_module()` and `data_merge_srv()`.
 
 # teal.transform 0.2.0
 

--- a/R/data_merge_module.R
+++ b/R/data_merge_module.R
@@ -1,9 +1,8 @@
 #' Data merge module
 #'
-#' @description `r lifecycle::badge("experimental")`
-#' @details This function is a convenient wrapper to combine `data_extract_multiple_srv()` and
+#' @description `r lifecycle::badge("deprecated")`
+#' @details This function was a convenient wrapper to combine `data_extract_multiple_srv()` and
 #' `data_merge_srv()` when no additional processing is required.
-#' Compare the example below with that found in [data_merge_srv()].
 #'
 #' @inheritParams shiny::moduleServer
 #' @param datasets (`FilteredData`)\cr
@@ -20,111 +19,20 @@
 #' @seealso [data_merge_srv()]
 #'
 #' @export
-#'
-#' @examples
-#' library(shiny)
-#'
-#' ADSL <- data.frame(
-#'   STUDYID = "A",
-#'   USUBJID = LETTERS[1:10],
-#'   SEX = rep(c("F", "M"), 5),
-#'   AGE = rpois(10, 30),
-#'   BMRKR1 = rlnorm(10)
-#' )
-#' ADLB <- expand.grid(
-#'   STUDYID = "A",
-#'   USUBJID = LETTERS[1:10],
-#'   PARAMCD = c("ALT", "CRP", "IGA"),
-#'   AVISIT = c("SCREENING", "BASELINE", "WEEK 1 DAY 8", "WEEK 2 DAY 15")
-#' )
-#' ADLB$AVAL <- rlnorm(120)
-#' ADLB$CHG <- rnorm(120)
-#'
-#' data <- teal.data::cdisc_data(
-#'   teal.data::cdisc_dataset("ADSL", ADSL),
-#'   teal.data::cdisc_dataset("ADLB", ADLB)
-#' )
-#' datasets <- teal.slice::init_filtered_data(data)
-#'
-#' adsl_extract <- data_extract_spec(
-#'   dataname = "ADSL",
-#'   select = select_spec(
-#'     label = "Select variable:",
-#'     choices = c("AGE", "BMRKR1"),
-#'     selected = "AGE",
-#'     multiple = TRUE,
-#'     fixed = FALSE
-#'   )
-#' )
-#' adlb_extract <- data_extract_spec(
-#'   dataname = "ADLB",
-#'   filter = filter_spec(vars = "PARAMCD", choices = c("ALT", "CRP", "IGA"), selected = "ALT"),
-#'   select = select_spec(
-#'     label = "Select variable:",
-#'     choices = c("AVAL", "CHG"),
-#'     selected = "AVAL",
-#'     multiple = TRUE,
-#'     fixed = FALSE
-#'   )
-#' )
-#' app <- shinyApp(
-#'   ui = fluidPage(
-#'     teal.widgets::standard_layout(
-#'       output = div(
-#'         verbatimTextOutput("expr"),
-#'         dataTableOutput("data")
-#'       ),
-#'       encoding = tagList(
-#'         data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
-#'         data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
-#'       )
-#'     )
-#'   ),
-#'   server = function(input, output, session) {
-#'     merged_data <- data_merge_module(
-#'       data_extract = list(adsl_var = adsl_extract, adlb_var = adlb_extract),
-#'       datasets = datasets,
-#'       merge_function = "dplyr::left_join"
-#'     )
-#'     output$expr <- renderText(merged_data()$expr)
-#'     output$data <- renderDataTable(merged_data()$data())
-#'   }
-#' )
-#' \dontrun{
-#' runApp(app)
-#' }
 data_merge_module <- function(datasets,
                               data_extract,
                               merge_function = "dplyr::full_join",
                               anl_name = "ANL",
                               id = "merge_id") {
-  logger::log_trace("data_merge_module called with: { paste(datasets$datanames(), collapse = ', ') } datasets.")
-
-  checkmate::assert_list(data_extract, c("list", "data_extract_spec", "NULL"))
-  lapply(data_extract, function(x) {
-    if (is.list(x) && !inherits(x, "data_extract_spec")) {
-      checkmate::assert_list(x, "data_extract_spec")
-    }
-  })
-
-  selector_list <- data_extract_multiple_srv(data_extract, datasets)
-
-  data_merge_srv(
-    id = id,
-    selector_list = selector_list,
-    datasets = datasets,
-    merge_function = merge_function,
-    anl_name = anl_name
-  )
+  lifecycle::deprecate_stop("0.3.1", "data_merge_module()")
 }
 
 
 #' Data merge module server
 #'
-#' @description `r lifecycle::badge("experimental")`
-#' @details When additional processing of the `data_extract` list input is required, `data_merge_srv()` can be combined
+#' @description `r lifecycle::badge("deprecated")`
+#' @details When additional processing of the `data_extract` list input was required, `data_merge_srv()` could be combined
 #'   with `data_extract_multiple_srv()` or `data_extract_srv()` to influence the `selector_list` input.
-#'   Compare the example below with that found in [data_merge_module()].
 #'
 #' @inheritParams shiny::moduleServer
 #' @param selector_list (`reactive`)\cr
@@ -144,139 +52,10 @@ data_merge_module <- function(datasets,
 #' @seealso [data_extract_srv()]
 #'
 #' @export
-#'
-#' @examples
-#' library(shiny)
-#'
-#' ADSL <- data.frame(
-#'   STUDYID = "A",
-#'   USUBJID = LETTERS[1:10],
-#'   SEX = rep(c("F", "M"), 5),
-#'   AGE = rpois(10, 30),
-#'   BMRKR1 = rlnorm(10)
-#' )
-#' ADLB <- expand.grid(
-#'   STUDYID = "A",
-#'   USUBJID = LETTERS[1:10],
-#'   PARAMCD = c("ALT", "CRP", "IGA"),
-#'   AVISIT = c("SCREENING", "BASELINE", "WEEK 1 DAY 8", "WEEK 2 DAY 15")
-#' )
-#' ADLB$AVAL <- rlnorm(120)
-#' ADLB$CHG <- rnorm(120)
-#'
-#' data <- teal.data::cdisc_data(
-#'   teal.data::cdisc_dataset("ADSL", ADSL),
-#'   teal.data::cdisc_dataset("ADLB", ADLB)
-#' )
-#' datasets <- teal.slice::init_filtered_data(data)
-#'
-#' adsl_extract <- data_extract_spec(
-#'   dataname = "ADSL",
-#'   select = select_spec(
-#'     label = "Select variable:",
-#'     choices = c("AGE", "BMRKR1"),
-#'     selected = "AGE",
-#'     multiple = TRUE,
-#'     fixed = FALSE
-#'   )
-#' )
-#' adlb_extract <- data_extract_spec(
-#'   dataname = "ADLB",
-#'   filter = filter_spec(vars = "PARAMCD", choices = c("ALT", "CRP", "IGA"), selected = "ALT"),
-#'   select = select_spec(
-#'     label = "Select variable:",
-#'     choices = c("AVAL", "CHG"),
-#'     selected = "AVAL",
-#'     multiple = TRUE,
-#'     fixed = FALSE
-#'   )
-#' )
-#'
-#' app <- shinyApp(
-#'   ui = fluidPage(
-#'     teal.widgets::standard_layout(
-#'       output = div(
-#'         verbatimTextOutput("expr"),
-#'         dataTableOutput("data")
-#'       ),
-#'       encoding = tagList(
-#'         data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
-#'         data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
-#'       )
-#'     )
-#'   ),
-#'   server = function(input, output, session) {
-#'     selector_list <- data_extract_multiple_srv(
-#'       list(adsl_var = adsl_extract, adlb_var = adlb_extract),
-#'       datasets
-#'     )
-#'     merged_data <- data_merge_srv(
-#'       selector_list = selector_list,
-#'       datasets = datasets,
-#'       merge_function = "dplyr::left_join"
-#'     )
-#'     output$expr <- renderText(merged_data()$expr)
-#'     output$data <- renderDataTable(merged_data()$data())
-#'   }
-#' )
-#' \dontrun{
-#' runApp(app)
-#' }
 data_merge_srv <- function(id = "merge_id",
                            selector_list,
                            datasets,
                            merge_function = "dplyr::full_join",
                            anl_name = "ANL") {
-  checkmate::assert_string(anl_name)
-  stopifnot(make.names(anl_name) == anl_name)
-  checkmate::assert_class(selector_list, "reactive")
-  checkmate::assert_class(datasets, "FilteredData")
-  moduleServer(
-    id,
-    function(input, output, session) {
-      logger::log_trace(
-        "data_merge_srv initialized with: { paste(datasets$datanames(), collapse = ', ') } datasets."
-      )
-      reactive({
-        checkmate::assert_list(selector_list(), names = "named", types = "reactive")
-        merge_fun_name <- if (inherits(merge_function, "reactive")) merge_function() else merge_function
-
-        datasets_list <- sapply(
-          datasets$datanames(),
-          simplify = FALSE,
-          function(x) reactive(datasets$get_data(x, filtered = TRUE))
-        )
-        join_keys <- datasets$get_join_keys()
-        check_merge_function(merge_fun_name)
-
-        # function to filter out selectors which are NULL or only have validator
-        f <- function(x) {
-          is.null(x) || (length(names(x)) == 1 && names(x) == "iv")
-        }
-
-        ds <- Filter(Negate(f), lapply(selector_list(), function(x) x()))
-
-        validate(need(length(ds) > 0, "At least one dataset needs to be selected"))
-        merged_data <- merge_datasets(
-          selector_list = ds,
-          datasets = datasets_list,
-          join_keys = join_keys,
-          merge_function = merge_fun_name,
-          anl_name = anl_name
-        )
-        ch <- teal.code::chunks_new()
-        datasets_list_nr <- sapply(datasets$datanames(), simplify = FALSE, datasets$get_data, filtered = TRUE)
-
-        teal.code::chunks_reset(envir = list2env(datasets_list_nr), chunks = ch)
-        for (chunk in merged_data$expr) teal.code::chunks_push(expression = chunk, chunks = ch)
-        teal.code::chunks_safe_eval(chunks = ch)
-        merged_data$data <- reactive({
-          ch$get(anl_name)
-        })
-        merged_data$chunks <- ch
-        merged_data$expr <- paste(merged_data$expr, collapse = "\n")
-        merged_data
-      })
-    }
-  )
+  lifecycle::deprecate_stop("0.3.1", "data_merge_module()")
 }

--- a/man/data_merge_module.Rd
+++ b/man/data_merge_module.Rd
@@ -32,85 +32,11 @@ UI function.}
 reactive expression with output from \code{\link[=data_merge_srv]{data_merge_srv()}}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \details{
-This function is a convenient wrapper to combine \code{data_extract_multiple_srv()} and
+This function was a convenient wrapper to combine \code{data_extract_multiple_srv()} and
 \code{data_merge_srv()} when no additional processing is required.
-Compare the example below with that found in \code{\link[=data_merge_srv]{data_merge_srv()}}.
-}
-\examples{
-library(shiny)
-
-ADSL <- data.frame(
-  STUDYID = "A",
-  USUBJID = LETTERS[1:10],
-  SEX = rep(c("F", "M"), 5),
-  AGE = rpois(10, 30),
-  BMRKR1 = rlnorm(10)
-)
-ADLB <- expand.grid(
-  STUDYID = "A",
-  USUBJID = LETTERS[1:10],
-  PARAMCD = c("ALT", "CRP", "IGA"),
-  AVISIT = c("SCREENING", "BASELINE", "WEEK 1 DAY 8", "WEEK 2 DAY 15")
-)
-ADLB$AVAL <- rlnorm(120)
-ADLB$CHG <- rnorm(120)
-
-data <- teal.data::cdisc_data(
-  teal.data::cdisc_dataset("ADSL", ADSL),
-  teal.data::cdisc_dataset("ADLB", ADLB)
-)
-datasets <- teal.slice::init_filtered_data(data)
-
-adsl_extract <- data_extract_spec(
-  dataname = "ADSL",
-  select = select_spec(
-    label = "Select variable:",
-    choices = c("AGE", "BMRKR1"),
-    selected = "AGE",
-    multiple = TRUE,
-    fixed = FALSE
-  )
-)
-adlb_extract <- data_extract_spec(
-  dataname = "ADLB",
-  filter = filter_spec(vars = "PARAMCD", choices = c("ALT", "CRP", "IGA"), selected = "ALT"),
-  select = select_spec(
-    label = "Select variable:",
-    choices = c("AVAL", "CHG"),
-    selected = "AVAL",
-    multiple = TRUE,
-    fixed = FALSE
-  )
-)
-app <- shinyApp(
-  ui = fluidPage(
-    teal.widgets::standard_layout(
-      output = div(
-        verbatimTextOutput("expr"),
-        dataTableOutput("data")
-      ),
-      encoding = tagList(
-        data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
-        data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
-      )
-    )
-  ),
-  server = function(input, output, session) {
-    merged_data <- data_merge_module(
-      data_extract = list(adsl_var = adsl_extract, adlb_var = adlb_extract),
-      datasets = datasets,
-      merge_function = "dplyr::left_join"
-    )
-    output$expr <- renderText(merged_data()$expr)
-    output$data <- renderDataTable(merged_data()$data())
-  }
-)
-\dontrun{
-runApp(app)
-}
 }
 \seealso{
 \code{\link[=data_merge_srv]{data_merge_srv()}}

--- a/man/data_merge_srv.Rd
+++ b/man/data_merge_srv.Rd
@@ -35,90 +35,11 @@ Name of the analysis dataset.}
 reactive expression with output from \link{merge_datasets}.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \details{
-When additional processing of the \code{data_extract} list input is required, \code{data_merge_srv()} can be combined
+When additional processing of the \code{data_extract} list input was required, \code{data_merge_srv()} could be combined
 with \code{data_extract_multiple_srv()} or \code{data_extract_srv()} to influence the \code{selector_list} input.
-Compare the example below with that found in \code{\link[=data_merge_module]{data_merge_module()}}.
-}
-\examples{
-library(shiny)
-
-ADSL <- data.frame(
-  STUDYID = "A",
-  USUBJID = LETTERS[1:10],
-  SEX = rep(c("F", "M"), 5),
-  AGE = rpois(10, 30),
-  BMRKR1 = rlnorm(10)
-)
-ADLB <- expand.grid(
-  STUDYID = "A",
-  USUBJID = LETTERS[1:10],
-  PARAMCD = c("ALT", "CRP", "IGA"),
-  AVISIT = c("SCREENING", "BASELINE", "WEEK 1 DAY 8", "WEEK 2 DAY 15")
-)
-ADLB$AVAL <- rlnorm(120)
-ADLB$CHG <- rnorm(120)
-
-data <- teal.data::cdisc_data(
-  teal.data::cdisc_dataset("ADSL", ADSL),
-  teal.data::cdisc_dataset("ADLB", ADLB)
-)
-datasets <- teal.slice::init_filtered_data(data)
-
-adsl_extract <- data_extract_spec(
-  dataname = "ADSL",
-  select = select_spec(
-    label = "Select variable:",
-    choices = c("AGE", "BMRKR1"),
-    selected = "AGE",
-    multiple = TRUE,
-    fixed = FALSE
-  )
-)
-adlb_extract <- data_extract_spec(
-  dataname = "ADLB",
-  filter = filter_spec(vars = "PARAMCD", choices = c("ALT", "CRP", "IGA"), selected = "ALT"),
-  select = select_spec(
-    label = "Select variable:",
-    choices = c("AVAL", "CHG"),
-    selected = "AVAL",
-    multiple = TRUE,
-    fixed = FALSE
-  )
-)
-
-app <- shinyApp(
-  ui = fluidPage(
-    teal.widgets::standard_layout(
-      output = div(
-        verbatimTextOutput("expr"),
-        dataTableOutput("data")
-      ),
-      encoding = tagList(
-        data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
-        data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
-      )
-    )
-  ),
-  server = function(input, output, session) {
-    selector_list <- data_extract_multiple_srv(
-      list(adsl_var = adsl_extract, adlb_var = adlb_extract),
-      datasets
-    )
-    merged_data <- data_merge_srv(
-      selector_list = selector_list,
-      datasets = datasets,
-      merge_function = "dplyr::left_join"
-    )
-    output$expr <- renderText(merged_data()$expr)
-    output$data <- renderDataTable(merged_data()$data())
-  }
-)
-\dontrun{
-runApp(app)
-}
 }
 \seealso{
 \code{\link[=data_extract_srv]{data_extract_srv()}}


### PR DESCRIPTION
Part of  https://github.com/insightsengineering/teal.code/issues/77

```{R}
> library(teal.transform)
> data_merge_module()
Error:
! `data_merge_module()` was deprecated in teal.transform 0.3.1 and is now
  defunct.
Run `rlang::last_trace()` to see where the error occurred.
> data_merge_srv()
Error:
! `data_merge_module()` was deprecated in teal.transform 0.3.1 and is now
  defunct.
Run `rlang::last_trace()` to see where the error occurred.
```