### PR TITLE
update repo roster link

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.transform 0.4.0.9006
+# teal.transform 0.4.0.9007
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ If you encounter a bug or you have a feature request - please file an issue. For
 
 ### Stargazers
 
-[![Stargazers repo roster for @insightsengineering/teal.transform](https://reporoster.com/stars/insightsengineering/teal.transform)](https://github.com/insightsengineering/teal.transform/stargazers)
+[![Stargazers repo roster for @insightsengineering/teal.transform](http://reporoster.com/stars/insightsengineering/teal.transform)](https://github.com/insightsengineering/teal.transform/stargazers)
 
 ### Forkers
 
-[![Forkers repo roster for @insightsengineering/teal.transform](https://reporoster.com/forks/insightsengineering/teal.transform)](https://github.com/insightsengineering/teal.transform/network/members)
+[![Forkers repo roster for @insightsengineering/teal.transform](http://reporoster.com/forks/insightsengineering/teal.transform)](https://github.com/insightsengineering/teal.transform/network/members)


### PR DESCRIPTION
Related with https://github.com/insightsengineering/teal/issues/949, updating the link to `reporoster` in README.