### PR TITLE
options for strict tests; few enhancements

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -3,3 +3,14 @@ linters: linters_with_defaults(
   cyclocomp_linter = NULL,
   object_usage_linter = NULL
   )
+exclusions: list(
+    "vignettes/data-extract-merge.Rmd" = list(
+      object_name_linter = Inf
+    ),
+    "vignettes/data-extract.Rmd" = list(
+      object_name_linter = Inf
+    ),
+    "vignettes/data-merge.Rmd" = list(
+      object_name_linter = Inf
+    )
+  )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,4 +59,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,21 +41,22 @@ Suggests:
     knitr (>= 1.42),
     rmarkdown (>= 2.19),
     teal.code (>= 0.4.1.9009),
-    testthat (>= 3.1.5)
+    testthat (>= 3.1.5),
+    withr (>= 2.0.0)
 VignetteBuilder:
     knitr
 RdMacros:
     lifecycle
 Config/Needs/verdepcheck: tidyverse/magrittr, mllg/checkmate,
     tidyverse/dplyr, r-lib/lifecycle, daroczig/logger, r-lib/rlang,
-    rstudio/rmarkdown, rstudio/shiny, daattali/shinyjs,
+    rstudio/shiny, daattali/shinyjs,
     rstudio/shinyvalidate, insightsengineering/teal.data,
     insightsengineering/teal.logger, insightsengineering/teal.widgets,
-    tidyverse/tidyr, r-lib/tidyselect, yihui/knitr,
-    insightsengineering/teal.code, r-lib/testthat
+    tidyverse/tidyr, r-lib/tidyselect, yihui/knitr, rstudio/rmarkdown
+    insightsengineering/teal.code, r-lib/testthat, r-lib/withr
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0

--- a/R/call_utils.R
+++ b/R/call_utils.R
@@ -385,8 +385,10 @@ call_extract_list <- function(dataname, varname, dollar = TRUE) {
 #' @param ... arguments to pass to function with name `name`
 #' @param unlist_args `list` extra arguments passed in a single list,
 #'   avoids the use of `do.call` with this function
-#' @examples
 #'
+#' @keywords internal
+#'
+#' @examples
 #' print_call_and_eval <- function(x) {
 #'   eval(print(x))
 #' }
@@ -394,7 +396,7 @@ call_extract_list <- function(dataname, varname, dollar = TRUE) {
 #' print_call_and_eval(
 #'   teal.transform:::call_with_colon("glue::glue", "x = {x}", x = 10)
 #' )
-#' \dontrun{
+#'
 #' # mtcars$cyl evaluated
 #' print_call_and_eval(
 #'   teal.transform:::call_with_colon("dplyr::filter", as.name("mtcars"), mtcars$cyl == 6)
@@ -420,8 +422,6 @@ call_extract_list <- function(dataname, varname, dollar = TRUE) {
 #' print_call_and_eval(
 #'   teal.transform:::call_with_colon("nb_args", arg1 = 1, unlist_args = list(arg2 = 2, args2 = 2))
 #' )
-#' }
-#' @keywords internal
 call_with_colon <- function(name, ..., unlist_args = list()) {
   checkmate::assert_string(name)
   checkmate::assert_list(unlist_args)
@@ -443,6 +443,7 @@ call_with_colon <- function(name, ..., unlist_args = list()) {
 #'   list containing calls to be combined by `operator`
 #'
 #' @return call
+#'
 #' @examples
 #' teal.transform:::calls_combine_by(
 #'   "&",

--- a/R/choices_labeled.R
+++ b/R/choices_labeled.R
@@ -22,8 +22,8 @@
 #' @examples
 #' library(shiny)
 #'
-#' ADSL <- teal.transform::rADSL
-#' ADTTE <- teal.transform::rADTTE
+#' ADSL <- rADSL
+#' ADTTE <- rADTTE
 #' choices1 <- choices_labeled(names(ADSL), teal.data::col_labels(ADSL, fill = FALSE))
 #' choices2 <- choices_labeled(ADTTE$PARAMCD, ADTTE$PARAM)
 #' # if only a subset of variables are needed, use subset argument
@@ -139,7 +139,7 @@ choices_labeled <- function(choices, labels, subset = NULL, types = NULL) {
 #' @export
 #'
 #' @examples
-#' ADRS <- teal.transform::rADRS
+#' ADRS <- rADRS
 #' variable_choices(ADRS)
 #' variable_choices(ADRS, subset = c("PARAM", "PARAMCD"))
 #' variable_choices(ADRS, subset = c("", "PARAM", "PARAMCD"))
@@ -253,7 +253,7 @@ variable_choices.data.frame <- function(data, subset = NULL, fill = TRUE, key = 
 #' @export
 #'
 #' @examples
-#' ADRS <- teal.transform::rADRS
+#' ADRS <- rADRS
 #' value_choices(ADRS, "PARAMCD", "PARAM", subset = c("BESRSPI", "INVET"))
 #' value_choices(ADRS, c("PARAMCD", "ARMCD"), c("PARAM", "ARM"))
 #' value_choices(ADRS, c("PARAMCD", "ARMCD"), c("PARAM", "ARM"),

--- a/R/choices_selected.R
+++ b/R/choices_selected.R
@@ -34,7 +34,6 @@ no_select_keyword <- "-- no selection --"
 #' @export
 #'
 #' @examples
-#'
 #' library(shiny)
 #'
 #' # all_choices example - semantically the same objects
@@ -46,7 +45,7 @@ no_select_keyword <- "-- no selection --"
 #'   selected = "C"
 #' )
 #'
-#' ADSL <- teal.transform::rADSL
+#' ADSL <- rADSL
 #' choices_selected(variable_choices(ADSL), "SEX")
 #'
 #' # How to select nothing

--- a/R/data_extract_filter_module.R
+++ b/R/data_extract_filter_module.R
@@ -134,10 +134,10 @@ data_extract_filter_srv <- function(id, datasets, filter) {
 #' @keywords internal
 #'
 #' @examples
-#' filtered_data_list <- list(iris = reactive(head(iris)))
+#' filtered_data_list <- list(iris = shiny::reactive(head(iris)))
 #' filter <- filter_spec(vars = colnames(iris)[1])
 #' filter$dataname <- "iris"
-#' isolate(
+#' shiny::isolate(
 #'   teal.transform:::get_initial_filter_values(filter = filter, datasets = filtered_data_list)
 #' )
 #'

--- a/R/data_extract_filter_module.R
+++ b/R/data_extract_filter_module.R
@@ -134,10 +134,10 @@ data_extract_filter_srv <- function(id, datasets, filter) {
 #' @keywords internal
 #'
 #' @examples
-#' filtered_data_list <- list(iris = shiny::reactive(utils::head(iris)))
+#' filtered_data_list <- list(iris = reactive(head(iris)))
 #' filter <- filter_spec(vars = colnames(iris)[1])
 #' filter$dataname <- "iris"
-#' shiny::isolate(
+#' isolate(
 #'   teal.transform:::get_initial_filter_values(filter = filter, datasets = filtered_data_list)
 #' )
 #'

--- a/R/data_extract_module.R
+++ b/R/data_extract_module.R
@@ -22,7 +22,7 @@ id_for_dataset <- function(dataname) {
 #' @keywords internal
 #' @examples
 #' teal.transform:::cond_data_extract_single_ui(
-#'   NS("TEST"),
+#'   shiny::NS("TEST"),
 #'   data_extract_spec(dataname = "test")
 #' )
 cond_data_extract_single_ui <- function(ns, single_data_extract_spec) {

--- a/R/data_extract_module.R
+++ b/R/data_extract_module.R
@@ -22,7 +22,7 @@ id_for_dataset <- function(dataname) {
 #' @keywords internal
 #' @examples
 #' teal.transform:::cond_data_extract_single_ui(
-#'   shiny::NS("TEST"),
+#'   NS("TEST"),
 #'   data_extract_spec(dataname = "test")
 #' )
 cond_data_extract_single_ui <- function(ns, single_data_extract_spec) {
@@ -278,7 +278,6 @@ check_data_extract_spec_react <- function(datasets, data_extract) {
 #' @export
 #'
 #' @examples
-#'
 #' library(shiny)
 #' library(shinyvalidate)
 #'
@@ -307,74 +306,73 @@ check_data_extract_spec_react <- function(datasets, data_extract) {
 #'
 #' join_keys <- teal.data::join_keys(teal.data::join_key("ADSL", "ADSL", c("STUDYID", "USUBJID")))
 #'
-#' app <- shinyApp(
-#'   ui = fluidPage(
-#'     teal.widgets::standard_layout(
-#'       output = verbatimTextOutput("out1"),
-#'       encoding = tagList(
-#'         data_extract_ui(
-#'           id = "adsl_var",
-#'           label = "ADSL selection",
-#'           data_extract_spec = adsl_extract
-#'         )
+#' ui <- fluidPage(
+#'   teal.widgets::standard_layout(
+#'     output = verbatimTextOutput("out1"),
+#'     encoding = tagList(
+#'       data_extract_ui(
+#'         id = "adsl_var",
+#'         label = "ADSL selection",
+#'         data_extract_spec = adsl_extract
 #'       )
 #'     )
-#'   ),
-#'   server = function(input, output, session) {
-#'     adsl_reactive_input <- data_extract_srv(
-#'       id = "adsl_var",
-#'       datasets = data_list,
-#'       data_extract_spec = adsl_extract,
-#'       join_keys = join_keys,
-#'       select_validation_rule = sv_required("Please select a variable.")
-#'     )
-#'
-#'     iv_r <- reactive({
-#'       iv <- InputValidator$new()
-#'       iv$add_validator(adsl_reactive_input()$iv)
-#'       iv$enable()
-#'       iv
-#'     })
-#'
-#'     output$out1 <- renderPrint({
-#'       if (iv_r()$is_valid()) {
-#'         cat(format_data_extract(adsl_reactive_input()))
-#'       } else {
-#'         "Please fix errors in your selection"
-#'       }
-#'     })
-#'   }
+#'   )
 #' )
+#'
+#' server <- function(input, output, session) {
+#'   adsl_reactive_input <- data_extract_srv(
+#'     id = "adsl_var",
+#'     datasets = data_list,
+#'     data_extract_spec = adsl_extract,
+#'     join_keys = join_keys,
+#'     select_validation_rule = sv_required("Please select a variable.")
+#'   )
+#'
+#'   iv_r <- reactive({
+#'     iv <- InputValidator$new()
+#'     iv$add_validator(adsl_reactive_input()$iv)
+#'     iv$enable()
+#'     iv
+#'   })
+#'
+#'   output$out1 <- renderPrint({
+#'     if (iv_r()$is_valid()) {
+#'       cat(format_data_extract(adsl_reactive_input()))
+#'     } else {
+#'       "Please fix errors in your selection"
+#'     }
+#'   })
+#' }
+#'
 #' if (interactive()) {
-#'   shinyApp(app$ui, app$server)
+#'   shinyApp(ui, server)
 #' }
 #'
 #'
-#' app <- shinyApp(
-#'   ui = fluidPage(
-#'     teal.widgets::standard_layout(
-#'       output = verbatimTextOutput("out1"),
-#'       encoding = tagList(
-#'         data_extract_ui(
-#'           id = "adsl_var",
-#'           label = "ADSL selection",
-#'           data_extract_spec = adsl_extract
-#'         )
+#' ui <- fluidPage(
+#'   teal.widgets::standard_layout(
+#'     output = verbatimTextOutput("out1"),
+#'     encoding = tagList(
+#'       data_extract_ui(
+#'         id = "adsl_var",
+#'         label = "ADSL selection",
+#'         data_extract_spec = adsl_extract
 #'       )
 #'     )
-#'   ),
-#'   server = function(input, output, session) {
-#'     adsl_reactive_input <- data_extract_srv(
-#'       id = "adsl_var",
-#'       datasets = datasets,
-#'       data_extract_spec = adsl_extract
-#'     )
-#'
-#'     output$out1 <- renderPrint(adsl_reactive_input())
-#'   }
+#'   )
 #' )
+#'
+#' server <- function(input, output, session) {
+#'   adsl_reactive_input <- data_extract_srv(
+#'     id = "adsl_var",
+#'     datasets = data_list,
+#'     data_extract_spec = adsl_extract
+#'   )
+#'   output$out1 <- renderPrint(adsl_reactive_input())
+#' }
+#'
 #' if (interactive()) {
-#'   shinyApp(app$ui, app$server)
+#'   shinyApp(ui, server)
 #' }
 data_extract_srv <- function(id, datasets, data_extract_spec, ...) {
   checkmate::assert_multi_class(datasets, c("FilteredData", "list"))
@@ -584,66 +582,65 @@ data_extract_srv.list <- function(id, datasets, data_extract_spec, join_keys = N
 #'
 #' data_list <- list(iris = reactive(iris))
 #'
-#' app <- shinyApp(
-#'   ui = fluidPage(
-#'     useShinyjs(),
-#'     standard_layout(
-#'       output = verbatimTextOutput("out1"),
-#'       encoding = tagList(
-#'         data_extract_ui(
-#'           id = "x_var",
-#'           label = "Please select an X column",
-#'           data_extract_spec = iris_select
-#'         ),
-#'         data_extract_ui(
-#'           id = "species_var",
-#'           label = "Please select 2 Species",
-#'           data_extract_spec = iris_filter
-#'         )
-#'       )
-#'     )
-#'   ),
-#'   server = function(input, output, session) {
-#'     exactly_2_validation <- function(msg) {
-#'       ~ if (length(.) != 2) msg
-#'     }
-#'
-#'
-#'     selector_list <- data_extract_multiple_srv(
-#'       list(x_var = iris_select, species_var = iris_filter),
-#'       datasets = data_list,
-#'       select_validation_rule = list(
-#'         x_var = sv_required("Please select an X column")
+#' ui <- fluidPage(
+#'   useShinyjs(),
+#'   standard_layout(
+#'     output = verbatimTextOutput("out1"),
+#'     encoding = tagList(
+#'       data_extract_ui(
+#'         id = "x_var",
+#'         label = "Please select an X column",
+#'         data_extract_spec = iris_select
 #'       ),
-#'       filter_validation_rule = list(
-#'         species_var = compose_rules(
-#'           sv_required("Exactly 2 Species must be chosen"),
-#'           exactly_2_validation("Exactly 2 Species must be chosen")
-#'         )
+#'       data_extract_ui(
+#'         id = "species_var",
+#'         label = "Please select 2 Species",
+#'         data_extract_spec = iris_filter
 #'       )
 #'     )
-#'     iv_r <- reactive({
-#'       iv <- InputValidator$new()
-#'       compose_and_enable_validators(
-#'         iv,
-#'         selector_list,
-#'         validator_names = NULL
-#'       )
-#'     })
-#'
-#'     output$out1 <- renderPrint({
-#'       if (iv_r()$is_valid()) {
-#'         ans <- lapply(selector_list(), function(x) {
-#'           cat(format_data_extract(x()), "\n\n")
-#'         })
-#'       } else {
-#'         "Please fix errors in your selection"
-#'       }
-#'     })
-#'   }
+#'   )
 #' )
+#'
+#' server <- function(input, output, session) {
+#'   exactly_2_validation <- function(msg) {
+#'     ~ if (length(.data$.) != 2) .data$msg
+#'   }
+#'
+#'   selector_list <- data_extract_multiple_srv(
+#'     list(x_var = iris_select, species_var = iris_filter),
+#'     datasets = data_list,
+#'     select_validation_rule = list(
+#'       x_var = sv_required("Please select an X column")
+#'     ),
+#'     filter_validation_rule = list(
+#'       species_var = compose_rules(
+#'         sv_required("Exactly 2 Species must be chosen"),
+#'         exactly_2_validation("Exactly 2 Species must be chosen")
+#'       )
+#'     )
+#'   )
+#'   iv_r <- reactive({
+#'     iv <- InputValidator$new()
+#'     compose_and_enable_validators(
+#'       iv,
+#'       selector_list,
+#'       validator_names = NULL
+#'     )
+#'   })
+#'
+#'   output$out1 <- renderPrint({
+#'     if (iv_r()$is_valid()) {
+#'       ans <- lapply(selector_list(), function(x) {
+#'         cat(format_data_extract(x()), "\n\n")
+#'       })
+#'     } else {
+#'       "Please fix errors in your selection"
+#'     }
+#'   })
+#' }
+#'
 #' if (interactive()) {
-#'   shinyApp(app$ui, app$server)
+#'   shinyApp(ui, server)
 #' }
 data_extract_multiple_srv <- function(data_extract, datasets, ...) {
   checkmate::assert_list(data_extract, names = "named")

--- a/R/filter_spec.R
+++ b/R/filter_spec.R
@@ -222,7 +222,7 @@ filter_spec <- function(vars,
 #'   vars_multiple = TRUE
 #' )
 #'
-#' ADRS <- teal.transform::rADRS
+#' ADRS <- rADRS
 #' teal.transform:::filter_spec_internal(
 #'   vars_choices = variable_choices(ADRS),
 #'   vars_selected = "PARAMCD",

--- a/R/format_data_extract.R
+++ b/R/format_data_extract.R
@@ -14,15 +14,17 @@
 #' )
 #'
 #' if (interactive()) {
-#'   shiny::shinyApp(
-#'     ui = shiny::fluidPage(
+#'   library(shiny)
+#'
+#'   shinyApp(
+#'     ui = fluidPage(
 #'       data_extract_ui(
 #'         id = "extract",
 #'         label = "data extract ui",
 #'         data_extract_spec = simple_des,
 #'         is_single_dataset = TRUE
 #'       ),
-#'       shiny::verbatimTextOutput("formatted_extract")
+#'       verbatimTextOutput("formatted_extract")
 #'     ),
 #'     server = function(input, output, session) {
 #'       extracted_input <- data_extract_srv(
@@ -30,7 +32,7 @@
 #'         datasets = list(iris = iris),
 #'         data_extract_spec = simple_des
 #'       )
-#'       output$formatted_extract <- shiny::renderPrint({
+#'       output$formatted_extract <- renderPrint({
 #'         cat(format_data_extract(extracted_input()))
 #'       })
 #'     }

--- a/R/merge_datasets.R
+++ b/R/merge_datasets.R
@@ -21,6 +21,7 @@
 #' - `filter_info` (`list`) The information given by the user. This information
 #'    defines the filters that are applied on the data. Additionally it defines
 #'    the variables that are selected from the data sets.
+#'
 #' @export
 #'
 #' @examples

--- a/R/merge_expression_module.R
+++ b/R/merge_expression_module.R
@@ -21,10 +21,13 @@
 #'
 #' @return reactive expression with output from [merge_expression_srv()].
 #'
+#' @export
+#'
 #' @seealso [merge_expression_srv()]
 #'
 #' @examples
 #' library(shiny)
+#'
 #' ADSL <- data.frame(
 #'   STUDYID = "A",
 #'   USUBJID = LETTERS[1:10],
@@ -74,65 +77,65 @@
 #'     fixed = FALSE
 #'   )
 #' )
-#' app <- shinyApp(
-#'   ui = fluidPage(
-#'     teal.widgets::standard_layout(
-#'       output = div(
-#'         verbatimTextOutput("expr"),
-#'         dataTableOutput("data")
-#'       ),
-#'       encoding = tagList(
-#'         data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
-#'         data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
-#'       )
+#'
+#' ui <- fluidPage(
+#'   teal.widgets::standard_layout(
+#'     output = div(
+#'       verbatimTextOutput("expr"),
+#'       dataTableOutput("data")
+#'     ),
+#'     encoding = tagList(
+#'       data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
+#'       data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
 #'     )
-#'   ),
-#'   server = function(input, output, session) {
-#'     data_q <- teal.code::qenv()
-#'
-#'     data_q <- teal.code::eval_code(
-#'       data_q,
-#'       "ADSL <- data.frame(
-#'         STUDYID = 'A',
-#'         USUBJID = LETTERS[1:10],
-#'         SEX = rep(c('F', 'M'), 5),
-#'         AGE = rpois(10, 30),
-#'         BMRKR1 = rlnorm(10)
-#'       )"
-#'     )
-#'
-#'     data_q <- teal.code::eval_code(
-#'       data_q,
-#'       "ADLB <- expand.grid(
-#'         STUDYID = 'A',
-#'         USUBJID = LETTERS[1:10],
-#'         PARAMCD = c('ALT', 'CRP', 'IGA'),
-#'         AVISIT = c('SCREENING', 'BASELINE', 'WEEK 1 DAY 8', 'WEEK 2 DAY 15'),
-#'         AVAL = rlnorm(120),
-#'         CHG = rlnorm(120)
-#'        )"
-#'     )
-#'
-#'     merged_data <- merge_expression_module(
-#'       data_extract = list(adsl_var = adsl_extract, adlb_var = adlb_extract),
-#'       datasets = data_list,
-#'       join_keys = join_keys,
-#'       merge_function = "dplyr::left_join"
-#'     )
-#'
-#'     code_merge <- reactive({
-#'       for (exp in merged_data()$expr) data_q <- teal.code::eval_code(data_q, exp)
-#'       data_q
-#'     })
-#'
-#'     output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
-#'     output$data <- renderDataTable(code_merge()[["ANL"]])
-#'   }
+#'   )
 #' )
-#' \dontrun{
-#' shinyApp(app$ui, app$server)
+#'
+#' server <- function(input, output, session) {
+#'   data_q <- teal.code::qenv()
+#'
+#'   data_q <- teal.code::eval_code(
+#'     data_q,
+#'     "ADSL <- data.frame(
+#'       STUDYID = 'A',
+#'       USUBJID = LETTERS[1:10],
+#'       SEX = rep(c('F', 'M'), 5),
+#'       AGE = rpois(10, 30),
+#'       BMRKR1 = rlnorm(10)
+#'     )"
+#'   )
+#'
+#'   data_q <- teal.code::eval_code(
+#'     data_q,
+#'     "ADLB <- expand.grid(
+#'       STUDYID = 'A',
+#'       USUBJID = LETTERS[1:10],
+#'       PARAMCD = c('ALT', 'CRP', 'IGA'),
+#'       AVISIT = c('SCREENING', 'BASELINE', 'WEEK 1 DAY 8', 'WEEK 2 DAY 15'),
+#'       AVAL = rlnorm(120),
+#'       CHG = rlnorm(120)
+#'      )"
+#'   )
+#'
+#'   merged_data <- merge_expression_module(
+#'     data_extract = list(adsl_var = adsl_extract, adlb_var = adlb_extract),
+#'     datasets = data_list,
+#'     join_keys = join_keys,
+#'     merge_function = "dplyr::left_join"
+#'   )
+#'
+#'   code_merge <- reactive({
+#'     for (exp in merged_data()$expr) data_q <- teal.code::eval_code(data_q, exp)
+#'     data_q
+#'   })
+#'
+#'   output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
+#'   output$data <- renderDataTable(code_merge()[["ANL"]])
 #' }
-#' @export
+#'
+#' \dontrun{
+#' shinyApp(ui, server)
+#' }
 merge_expression_module <- function(datasets,
                                     join_keys = NULL,
                                     data_extract,
@@ -272,67 +275,67 @@ merge_expression_module.list <- function(datasets,
 #'   )
 #' )
 #'
-#' app <- shinyApp(
-#'   ui = fluidPage(
-#'     teal.widgets::standard_layout(
-#'       output = div(
-#'         verbatimTextOutput("expr"),
-#'         dataTableOutput("data")
-#'       ),
-#'       encoding = tagList(
-#'         data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
-#'         data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
-#'       )
+#' ui <- fluidPage(
+#'   teal.widgets::standard_layout(
+#'     output = div(
+#'       verbatimTextOutput("expr"),
+#'       dataTableOutput("data")
+#'     ),
+#'     encoding = tagList(
+#'       data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
+#'       data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
 #'     )
-#'   ),
-#'   server = function(input, output, session) {
-#'     data_q <- teal.code::qenv()
-#'
-#'     data_q <- teal.code::eval_code(
-#'       data_q,
-#'       "ADSL <- data.frame(
-#'         STUDYID = 'A',
-#'         USUBJID = LETTERS[1:10],
-#'         SEX = rep(c('F', 'M'), 5),
-#'         AGE = rpois(10, 30),
-#'         BMRKR1 = rlnorm(10)
-#'       )"
-#'     )
-#'
-#'     data_q <- teal.code::eval_code(
-#'       data_q,
-#'       "ADLB <- expand.grid(
-#'         STUDYID = 'A',
-#'         USUBJID = LETTERS[1:10],
-#'         PARAMCD = c('ALT', 'CRP', 'IGA'),
-#'         AVISIT = c('SCREENING', 'BASELINE', 'WEEK 1 DAY 8', 'WEEK 2 DAY 15'),
-#'         AVAL = rlnorm(120),
-#'         CHG = rlnorm(120)
-#'       )"
-#'     )
-#'
-#'     selector_list <- data_extract_multiple_srv(
-#'       list(adsl_var = adsl_extract, adlb_var = adlb_extract),
-#'       datasets = data_list
-#'     )
-#'     merged_data <- merge_expression_srv(
-#'       selector_list = selector_list,
-#'       datasets = data_list,
-#'       join_keys = join_keys,
-#'       merge_function = "dplyr::left_join"
-#'     )
-#'
-#'     code_merge <- reactive({
-#'       for (exp in merged_data()$expr) data_q <- teal.code::eval_code(data_q, exp)
-#'       data_q
-#'     })
-#'
-#'     output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
-#'     output$data <- renderDataTable(code_merge()[["ANL"]])
-#'   }
+#'   )
 #' )
+#'
+#' server <- function(input, output, session) {
+#'   data_q <- teal.code::qenv()
+#'
+#'   data_q <- teal.code::eval_code(
+#'     data_q,
+#'     "ADSL <- data.frame(
+#'       STUDYID = 'A',
+#'       USUBJID = LETTERS[1:10],
+#'       SEX = rep(c('F', 'M'), 5),
+#'       AGE = rpois(10, 30),
+#'       BMRKR1 = rlnorm(10)
+#'     )"
+#'   )
+#'
+#'   data_q <- teal.code::eval_code(
+#'     data_q,
+#'     "ADLB <- expand.grid(
+#'       STUDYID = 'A',
+#'       USUBJID = LETTERS[1:10],
+#'       PARAMCD = c('ALT', 'CRP', 'IGA'),
+#'       AVISIT = c('SCREENING', 'BASELINE', 'WEEK 1 DAY 8', 'WEEK 2 DAY 15'),
+#'       AVAL = rlnorm(120),
+#'       CHG = rlnorm(120)
+#'     )"
+#'   )
+#'
+#'   selector_list <- data_extract_multiple_srv(
+#'     list(adsl_var = adsl_extract, adlb_var = adlb_extract),
+#'     datasets = data_list
+#'   )
+#'   merged_data <- merge_expression_srv(
+#'     selector_list = selector_list,
+#'     datasets = data_list,
+#'     join_keys = join_keys,
+#'     merge_function = "dplyr::left_join"
+#'   )
+#'
+#'   code_merge <- reactive({
+#'     for (exp in merged_data()$expr) data_q <- teal.code::eval_code(data_q, exp)
+#'     data_q
+#'   })
+#'
+#'   output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
+#'   output$data <- renderDataTable(code_merge()[["ANL"]])
+#' }
+#'
 #' \dontrun{
-#' shinyApp(app$ui, app$server)
+#' shinyApp(ui, server)
 #' }
 merge_expression_srv <- function(id = "merge_id",
                                  selector_list,

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -12,9 +12,9 @@
 #' @examples
 #' ADSL <- rADSL
 #' attr(ADSL, "keys") <- c("STUDYID", "USUBJID")
-#' data_list <- list(ADSL = reactive(ADSL))
+#' data_list <- list(ADSL = shiny::reactive(ADSL))
 #' keys <- list(ADSL = attr(ADSL, "keys"))
-#' isolate({
+#' shiny::isolate({
 #'   # value_choices example
 #'   v1 <- value_choices("ADSL", "SEX", "SEX")
 #'   v1

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -10,11 +10,11 @@
 #' @return Resolved object.
 #'
 #' @examples
-#' ADSL <- teal.transform::rADSL
+#' ADSL <- rADSL
 #' attr(ADSL, "keys") <- c("STUDYID", "USUBJID")
-#' data_list <- list(ADSL = shiny::reactive(ADSL))
+#' data_list <- list(ADSL = reactive(ADSL))
 #' keys <- list(ADSL = attr(ADSL, "keys"))
-#' shiny::isolate({
+#' isolate({
 #'   # value_choices example
 #'   v1 <- value_choices("ADSL", "SEX", "SEX")
 #'   v1
@@ -104,7 +104,7 @@ resolve.delayed_choices_selected <- function(x, datasets, keys) { # nolint
   x$choices <- resolve(x$choices, datasets = datasets, keys)
 
   if (!all(x$selected %in% x$choices)) {
-    logger::log_warn(paste(
+    warning(paste(
       "Removing",
       paste(x$selected[which(!x$selected %in% x$choices)]),
       "from 'selected' as not in 'choices' when resolving delayed choices_selected"
@@ -179,6 +179,7 @@ resolve.default <- function(x, datasets, keys) {
 #' @param is_value_choices (`logical`) Determines which check of the returned value will be applied.
 #'
 #' @return Character vector - result of calling function `x` on dataset `ds`.
+#'
 #' @keywords internal
 #'
 #' @examples

--- a/R/resolve_delayed.R
+++ b/R/resolve_delayed.R
@@ -12,9 +12,9 @@
 #' @export
 #'
 #' @examples
-#' ADSL <- teal.transform::rADSL
-#' shiny::isolate({
-#'   data_list <- list(ADSL = shiny::reactive(ADSL))
+#' ADSL <- rADSL
+#' isolate({
+#'   data_list <- list(ADSL = reactive(ADSL))
 #'
 #'   # value_choices example
 #'   v1 <- value_choices("ADSL", "SEX", "SEX")

--- a/R/resolve_delayed.R
+++ b/R/resolve_delayed.R
@@ -13,8 +13,8 @@
 #'
 #' @examples
 #' ADSL <- rADSL
-#' isolate({
-#'   data_list <- list(ADSL = reactive(ADSL))
+#' shiny::isolate({
+#'   data_list <- list(ADSL = shiny::reactive(ADSL))
 #'
 #'   # value_choices example
 #'   v1 <- value_choices("ADSL", "SEX", "SEX")

--- a/R/utils.R
+++ b/R/utils.R
@@ -75,71 +75,69 @@ extract_choices_labels <- function(choices, values = NULL) {
 #'
 #' data_list <- list(iris = reactive(iris))
 #'
-#' app <- shinyApp(
-#'   ui = fluidPage(
-#'     useShinyjs(),
-#'     standard_layout(
-#'       output = verbatimTextOutput("out1"),
-#'       encoding = tagList(
-#'         data_extract_ui(
-#'           id = "x_var",
-#'           label = "Please select an X column",
-#'           data_extract_spec = iris_extract
-#'         ),
-#'         data_extract_ui(
-#'           id = "y_var",
-#'           label = "Please select a Y column",
-#'           data_extract_spec = iris_extract
-#'         ),
-#'         data_extract_ui(
-#'           id = "col_var",
-#'           label = "Please select a color column",
-#'           data_extract_spec = iris_extract
-#'         )
+#' ui <- fluidPage(
+#'   useShinyjs(),
+#'   standard_layout(
+#'     output = verbatimTextOutput("out1"),
+#'     encoding = tagList(
+#'       data_extract_ui(
+#'         id = "x_var",
+#'         label = "Please select an X column",
+#'         data_extract_spec = iris_extract
+#'       ),
+#'       data_extract_ui(
+#'         id = "y_var",
+#'         label = "Please select a Y column",
+#'         data_extract_spec = iris_extract
+#'       ),
+#'       data_extract_ui(
+#'         id = "col_var",
+#'         label = "Please select a color column",
+#'         data_extract_spec = iris_extract
 #'       )
 #'     )
-#'   ),
-#'   server = function(input, output, session) {
-#'     exactly_2_validation <- function() {
-#'       ~ if (length(.) != 2) "Exactly 2 'Y' column variables must be chosen"
-#'     }
-#'
-#'
-#'     selector_list <- data_extract_multiple_srv(
-#'       list(x_var = iris_extract, y_var = iris_extract, col_var = iris_extract),
-#'       datasets = data_list,
-#'       select_validation_rule = list(
-#'         x_var = sv_required("Please select an X column"),
-#'         y_var = compose_rules(
-#'           sv_required("Exactly 2 'Y' column variables must be chosen"),
-#'           exactly_2_validation()
-#'         )
-#'       )
-#'     )
-#'     iv_r <- reactive({
-#'       iv <- InputValidator$new()
-#'       compose_and_enable_validators(
-#'         iv,
-#'         selector_list,
-#'         # if validator_names = NULL then all validators are used
-#'         # to turn on only "x_var" then set this argument to "x_var"
-#'         validator_names = NULL
-#'       )
-#'     })
-#'
-#'     output$out1 <- renderPrint({
-#'       if (iv_r()$is_valid()) {
-#'         ans <- lapply(selector_list(), function(x) {
-#'           cat(format_data_extract(x()), "\n\n")
-#'         })
-#'       } else {
-#'         "Check that you have made a valid selection"
-#'       }
-#'     })
-#'   }
+#'   )
 #' )
+#'
+#' server <- function(input, output, session) {
+#'   exactly_2_validation <- function() {
+#'     ~ if (length(.data$.) != 2) "Exactly 2 'Y' column variables must be chosen"
+#'   }
+#'
+#'   selector_list <- data_extract_multiple_srv(
+#'     list(x_var = iris_extract, y_var = iris_extract, col_var = iris_extract),
+#'     datasets = data_list,
+#'     select_validation_rule = list(
+#'       x_var = sv_required("Please select an X column"),
+#'       y_var = compose_rules(
+#'         sv_required("Exactly 2 'Y' column variables must be chosen"),
+#'         exactly_2_validation()
+#'       )
+#'     )
+#'   )
+#'   iv_r <- reactive({
+#'     iv <- InputValidator$new()
+#'     compose_and_enable_validators(
+#'       iv,
+#'       selector_list,
+#'       # if validator_names = NULL then all validators are used
+#'       # to turn on only "x_var" then set this argument to "x_var"
+#'       validator_names = NULL
+#'     )
+#'   })
+#'
+#'   output$out1 <- renderPrint({
+#'     if (iv_r()$is_valid()) {
+#'       ans <- lapply(selector_list(), function(x) {
+#'         cat(format_data_extract(x()), "\n\n")
+#'       })
+#'     } else {
+#'       "Check that you have made a valid selection"
+#'     }
+#'   })
+#' }
 #' if (interactive()) {
-#'   shinyApp(app$ui, app$server)
+#'   shinyApp(ui, server)
 #' }
 compose_and_enable_validators <- function(iv, selector_list, validator_names = NULL) {
   if (is.null(validator_names)) {

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Below is a small example usage:
 
 ```r
 library(teal.transform)
-ADSL <- teal.transform::rADSL
+ADSL <- rADSL
 
 adsl_extract <- data_extract_spec(
   dataname = "ADSL",

--- a/man/call_with_colon.Rd
+++ b/man/call_with_colon.Rd
@@ -19,7 +19,6 @@ avoids the use of \code{do.call} with this function}
 The arguments in ... need to be quoted because they will be evaluated otherwise
 }
 \examples{
-
 print_call_and_eval <- function(x) {
   eval(print(x))
 }
@@ -27,7 +26,7 @@ print_call_and_eval <- function(x) {
 print_call_and_eval(
   teal.transform:::call_with_colon("glue::glue", "x = {x}", x = 10)
 )
-\dontrun{
+
 # mtcars$cyl evaluated
 print_call_and_eval(
   teal.transform:::call_with_colon("dplyr::filter", as.name("mtcars"), mtcars$cyl == 6)
@@ -53,6 +52,5 @@ print_call_and_eval(
 print_call_and_eval(
   teal.transform:::call_with_colon("nb_args", arg1 = 1, unlist_args = list(arg2 = 2, args2 = 2))
 )
-}
 }
 \keyword{internal}

--- a/man/choices_labeled.Rd
+++ b/man/choices_labeled.Rd
@@ -43,8 +43,8 @@ Duplicated elements from \code{choices} get removed.
 \examples{
 library(shiny)
 
-ADSL <- teal.transform::rADSL
-ADTTE <- teal.transform::rADTTE
+ADSL <- rADSL
+ADTTE <- rADTTE
 choices1 <- choices_labeled(names(ADSL), teal.data::col_labels(ADSL, fill = FALSE))
 choices2 <- choices_labeled(ADTTE$PARAMCD, ADTTE$PARAM)
 # if only a subset of variables are needed, use subset argument

--- a/man/choices_selected.Rd
+++ b/man/choices_selected.Rd
@@ -53,7 +53,6 @@ argument is set to false which will run the following code inside:
 in case you want to keep your specific order of choices, set \code{keep_order} to \code{TRUE}.
 }
 \examples{
-
 library(shiny)
 
 # all_choices example - semantically the same objects
@@ -65,7 +64,7 @@ choices_selected(
   selected = "C"
 )
 
-ADSL <- teal.transform::rADSL
+ADSL <- rADSL
 choices_selected(variable_choices(ADSL), "SEX")
 
 # How to select nothing

--- a/man/compose_and_enable_validators.Rd
+++ b/man/compose_and_enable_validators.Rd
@@ -45,70 +45,68 @@ iris_extract <- data_extract_spec(
 
 data_list <- list(iris = reactive(iris))
 
-app <- shinyApp(
-  ui = fluidPage(
-    useShinyjs(),
-    standard_layout(
-      output = verbatimTextOutput("out1"),
-      encoding = tagList(
-        data_extract_ui(
-          id = "x_var",
-          label = "Please select an X column",
-          data_extract_spec = iris_extract
-        ),
-        data_extract_ui(
-          id = "y_var",
-          label = "Please select a Y column",
-          data_extract_spec = iris_extract
-        ),
-        data_extract_ui(
-          id = "col_var",
-          label = "Please select a color column",
-          data_extract_spec = iris_extract
-        )
+ui <- fluidPage(
+  useShinyjs(),
+  standard_layout(
+    output = verbatimTextOutput("out1"),
+    encoding = tagList(
+      data_extract_ui(
+        id = "x_var",
+        label = "Please select an X column",
+        data_extract_spec = iris_extract
+      ),
+      data_extract_ui(
+        id = "y_var",
+        label = "Please select a Y column",
+        data_extract_spec = iris_extract
+      ),
+      data_extract_ui(
+        id = "col_var",
+        label = "Please select a color column",
+        data_extract_spec = iris_extract
       )
     )
-  ),
-  server = function(input, output, session) {
-    exactly_2_validation <- function() {
-      ~ if (length(.) != 2) "Exactly 2 'Y' column variables must be chosen"
-    }
-
-
-    selector_list <- data_extract_multiple_srv(
-      list(x_var = iris_extract, y_var = iris_extract, col_var = iris_extract),
-      datasets = data_list,
-      select_validation_rule = list(
-        x_var = sv_required("Please select an X column"),
-        y_var = compose_rules(
-          sv_required("Exactly 2 'Y' column variables must be chosen"),
-          exactly_2_validation()
-        )
-      )
-    )
-    iv_r <- reactive({
-      iv <- InputValidator$new()
-      compose_and_enable_validators(
-        iv,
-        selector_list,
-        # if validator_names = NULL then all validators are used
-        # to turn on only "x_var" then set this argument to "x_var"
-        validator_names = NULL
-      )
-    })
-
-    output$out1 <- renderPrint({
-      if (iv_r()$is_valid()) {
-        ans <- lapply(selector_list(), function(x) {
-          cat(format_data_extract(x()), "\n\n")
-        })
-      } else {
-        "Check that you have made a valid selection"
-      }
-    })
-  }
+  )
 )
+
+server <- function(input, output, session) {
+  exactly_2_validation <- function() {
+    ~ if (length(.data$.) != 2) "Exactly 2 'Y' column variables must be chosen"
+  }
+
+  selector_list <- data_extract_multiple_srv(
+    list(x_var = iris_extract, y_var = iris_extract, col_var = iris_extract),
+    datasets = data_list,
+    select_validation_rule = list(
+      x_var = sv_required("Please select an X column"),
+      y_var = compose_rules(
+        sv_required("Exactly 2 'Y' column variables must be chosen"),
+        exactly_2_validation()
+      )
+    )
+  )
+  iv_r <- reactive({
+    iv <- InputValidator$new()
+    compose_and_enable_validators(
+      iv,
+      selector_list,
+      # if validator_names = NULL then all validators are used
+      # to turn on only "x_var" then set this argument to "x_var"
+      validator_names = NULL
+    )
+  })
+
+  output$out1 <- renderPrint({
+    if (iv_r()$is_valid()) {
+      ans <- lapply(selector_list(), function(x) {
+        cat(format_data_extract(x()), "\n\n")
+      })
+    } else {
+      "Check that you have made a valid selection"
+    }
+  })
+}
 if (interactive()) {
-  shinyApp(app$ui, app$server)
+  shinyApp(ui, server)
 }
 }

--- a/man/cond_data_extract_single_ui.Rd
+++ b/man/cond_data_extract_single_ui.Rd
@@ -23,7 +23,7 @@ conditionally on \code{input[ns("dataset")] == dataname}.
 }
 \examples{
 teal.transform:::cond_data_extract_single_ui(
-  shiny::NS("TEST"),
+  NS("TEST"),
   data_extract_spec(dataname = "test")
 )
 }

--- a/man/cond_data_extract_single_ui.Rd
+++ b/man/cond_data_extract_single_ui.Rd
@@ -23,7 +23,7 @@ conditionally on \code{input[ns("dataset")] == dataname}.
 }
 \examples{
 teal.transform:::cond_data_extract_single_ui(
-  NS("TEST"),
+  shiny::NS("TEST"),
   data_extract_spec(dataname = "test")
 )
 }

--- a/man/data_extract_multiple_srv.Rd
+++ b/man/data_extract_multiple_srv.Rd
@@ -95,65 +95,64 @@ iris_filter <- data_extract_spec(
 
 data_list <- list(iris = reactive(iris))
 
-app <- shinyApp(
-  ui = fluidPage(
-    useShinyjs(),
-    standard_layout(
-      output = verbatimTextOutput("out1"),
-      encoding = tagList(
-        data_extract_ui(
-          id = "x_var",
-          label = "Please select an X column",
-          data_extract_spec = iris_select
-        ),
-        data_extract_ui(
-          id = "species_var",
-          label = "Please select 2 Species",
-          data_extract_spec = iris_filter
-        )
-      )
-    )
-  ),
-  server = function(input, output, session) {
-    exactly_2_validation <- function(msg) {
-      ~ if (length(.) != 2) msg
-    }
-
-
-    selector_list <- data_extract_multiple_srv(
-      list(x_var = iris_select, species_var = iris_filter),
-      datasets = data_list,
-      select_validation_rule = list(
-        x_var = sv_required("Please select an X column")
+ui <- fluidPage(
+  useShinyjs(),
+  standard_layout(
+    output = verbatimTextOutput("out1"),
+    encoding = tagList(
+      data_extract_ui(
+        id = "x_var",
+        label = "Please select an X column",
+        data_extract_spec = iris_select
       ),
-      filter_validation_rule = list(
-        species_var = compose_rules(
-          sv_required("Exactly 2 Species must be chosen"),
-          exactly_2_validation("Exactly 2 Species must be chosen")
-        )
+      data_extract_ui(
+        id = "species_var",
+        label = "Please select 2 Species",
+        data_extract_spec = iris_filter
       )
     )
-    iv_r <- reactive({
-      iv <- InputValidator$new()
-      compose_and_enable_validators(
-        iv,
-        selector_list,
-        validator_names = NULL
-      )
-    })
-
-    output$out1 <- renderPrint({
-      if (iv_r()$is_valid()) {
-        ans <- lapply(selector_list(), function(x) {
-          cat(format_data_extract(x()), "\n\n")
-        })
-      } else {
-        "Please fix errors in your selection"
-      }
-    })
-  }
+  )
 )
+
+server <- function(input, output, session) {
+  exactly_2_validation <- function(msg) {
+    ~ if (length(.data$.) != 2) .data$msg
+  }
+
+  selector_list <- data_extract_multiple_srv(
+    list(x_var = iris_select, species_var = iris_filter),
+    datasets = data_list,
+    select_validation_rule = list(
+      x_var = sv_required("Please select an X column")
+    ),
+    filter_validation_rule = list(
+      species_var = compose_rules(
+        sv_required("Exactly 2 Species must be chosen"),
+        exactly_2_validation("Exactly 2 Species must be chosen")
+      )
+    )
+  )
+  iv_r <- reactive({
+    iv <- InputValidator$new()
+    compose_and_enable_validators(
+      iv,
+      selector_list,
+      validator_names = NULL
+    )
+  })
+
+  output$out1 <- renderPrint({
+    if (iv_r()$is_valid()) {
+      ans <- lapply(selector_list(), function(x) {
+        cat(format_data_extract(x()), "\n\n")
+      })
+    } else {
+      "Please fix errors in your selection"
+    }
+  })
+}
+
 if (interactive()) {
-  shinyApp(app$ui, app$server)
+  shinyApp(ui, server)
 }
 }

--- a/man/data_extract_srv.Rd
+++ b/man/data_extract_srv.Rd
@@ -76,7 +76,6 @@ A reactive \code{list} containing following fields:
 Extracting details of the selection(s) in \link{data_extract_ui} elements.
 }
 \examples{
-
 library(shiny)
 library(shinyvalidate)
 
@@ -105,74 +104,73 @@ data_list <- list(ADSL = reactive(ADSL))
 
 join_keys <- teal.data::join_keys(teal.data::join_key("ADSL", "ADSL", c("STUDYID", "USUBJID")))
 
-app <- shinyApp(
-  ui = fluidPage(
-    teal.widgets::standard_layout(
-      output = verbatimTextOutput("out1"),
-      encoding = tagList(
-        data_extract_ui(
-          id = "adsl_var",
-          label = "ADSL selection",
-          data_extract_spec = adsl_extract
-        )
+ui <- fluidPage(
+  teal.widgets::standard_layout(
+    output = verbatimTextOutput("out1"),
+    encoding = tagList(
+      data_extract_ui(
+        id = "adsl_var",
+        label = "ADSL selection",
+        data_extract_spec = adsl_extract
       )
     )
-  ),
-  server = function(input, output, session) {
-    adsl_reactive_input <- data_extract_srv(
-      id = "adsl_var",
-      datasets = data_list,
-      data_extract_spec = adsl_extract,
-      join_keys = join_keys,
-      select_validation_rule = sv_required("Please select a variable.")
-    )
-
-    iv_r <- reactive({
-      iv <- InputValidator$new()
-      iv$add_validator(adsl_reactive_input()$iv)
-      iv$enable()
-      iv
-    })
-
-    output$out1 <- renderPrint({
-      if (iv_r()$is_valid()) {
-        cat(format_data_extract(adsl_reactive_input()))
-      } else {
-        "Please fix errors in your selection"
-      }
-    })
-  }
+  )
 )
+
+server <- function(input, output, session) {
+  adsl_reactive_input <- data_extract_srv(
+    id = "adsl_var",
+    datasets = data_list,
+    data_extract_spec = adsl_extract,
+    join_keys = join_keys,
+    select_validation_rule = sv_required("Please select a variable.")
+  )
+
+  iv_r <- reactive({
+    iv <- InputValidator$new()
+    iv$add_validator(adsl_reactive_input()$iv)
+    iv$enable()
+    iv
+  })
+
+  output$out1 <- renderPrint({
+    if (iv_r()$is_valid()) {
+      cat(format_data_extract(adsl_reactive_input()))
+    } else {
+      "Please fix errors in your selection"
+    }
+  })
+}
+
 if (interactive()) {
-  shinyApp(app$ui, app$server)
+  shinyApp(ui, server)
 }
 
 
-app <- shinyApp(
-  ui = fluidPage(
-    teal.widgets::standard_layout(
-      output = verbatimTextOutput("out1"),
-      encoding = tagList(
-        data_extract_ui(
-          id = "adsl_var",
-          label = "ADSL selection",
-          data_extract_spec = adsl_extract
-        )
+ui <- fluidPage(
+  teal.widgets::standard_layout(
+    output = verbatimTextOutput("out1"),
+    encoding = tagList(
+      data_extract_ui(
+        id = "adsl_var",
+        label = "ADSL selection",
+        data_extract_spec = adsl_extract
       )
     )
-  ),
-  server = function(input, output, session) {
-    adsl_reactive_input <- data_extract_srv(
-      id = "adsl_var",
-      datasets = datasets,
-      data_extract_spec = adsl_extract
-    )
-
-    output$out1 <- renderPrint(adsl_reactive_input())
-  }
+  )
 )
+
+server <- function(input, output, session) {
+  adsl_reactive_input <- data_extract_srv(
+    id = "adsl_var",
+    datasets = data_list,
+    data_extract_spec = adsl_extract
+  )
+  output$out1 <- renderPrint(adsl_reactive_input())
+}
+
 if (interactive()) {
-  shinyApp(app$ui, app$server)
+  shinyApp(ui, server)
 }
 }
 \references{

--- a/man/filter_spec_internal.Rd
+++ b/man/filter_spec_internal.Rd
@@ -135,7 +135,7 @@ teal.transform:::filter_spec_internal(
   vars_multiple = TRUE
 )
 
-ADRS <- teal.transform::rADRS
+ADRS <- rADRS
 teal.transform:::filter_spec_internal(
   vars_choices = variable_choices(ADRS),
   vars_selected = "PARAMCD",

--- a/man/format_data_extract.Rd
+++ b/man/format_data_extract.Rd
@@ -26,15 +26,17 @@ simple_des <- data_extract_spec(
 )
 
 if (interactive()) {
-  shiny::shinyApp(
-    ui = shiny::fluidPage(
+  library(shiny)
+
+  shinyApp(
+    ui = fluidPage(
       data_extract_ui(
         id = "extract",
         label = "data extract ui",
         data_extract_spec = simple_des,
         is_single_dataset = TRUE
       ),
-      shiny::verbatimTextOutput("formatted_extract")
+      verbatimTextOutput("formatted_extract")
     ),
     server = function(input, output, session) {
       extracted_input <- data_extract_srv(
@@ -42,7 +44,7 @@ if (interactive()) {
         datasets = list(iris = iris),
         data_extract_spec = simple_des
       )
-      output$formatted_extract <- shiny::renderPrint({
+      output$formatted_extract <- renderPrint({
         cat(format_data_extract(extracted_input()))
       })
     }

--- a/man/get_initial_filter_values.Rd
+++ b/man/get_initial_filter_values.Rd
@@ -20,10 +20,10 @@ Returns the initial values for the \code{vals} widget
 of a \code{filter_spec} object.
 }
 \examples{
-filtered_data_list <- list(iris = reactive(head(iris)))
+filtered_data_list <- list(iris = shiny::reactive(head(iris)))
 filter <- filter_spec(vars = colnames(iris)[1])
 filter$dataname <- "iris"
-isolate(
+shiny::isolate(
   teal.transform:::get_initial_filter_values(filter = filter, datasets = filtered_data_list)
 )
 

--- a/man/get_initial_filter_values.Rd
+++ b/man/get_initial_filter_values.Rd
@@ -20,10 +20,10 @@ Returns the initial values for the \code{vals} widget
 of a \code{filter_spec} object.
 }
 \examples{
-filtered_data_list <- list(iris = shiny::reactive(utils::head(iris)))
+filtered_data_list <- list(iris = reactive(head(iris)))
 filter <- filter_spec(vars = colnames(iris)[1])
 filter$dataname <- "iris"
-shiny::isolate(
+isolate(
   teal.transform:::get_initial_filter_values(filter = filter, datasets = filtered_data_list)
 )
 

--- a/man/merge_expression_module.Rd
+++ b/man/merge_expression_module.Rd
@@ -67,6 +67,7 @@ Compare the example below with that found in \code{\link[=merge_expression_srv]{
 }
 \examples{
 library(shiny)
+
 ADSL <- data.frame(
   STUDYID = "A",
   USUBJID = LETTERS[1:10],
@@ -116,63 +117,64 @@ adlb_extract <- data_extract_spec(
     fixed = FALSE
   )
 )
-app <- shinyApp(
-  ui = fluidPage(
-    teal.widgets::standard_layout(
-      output = div(
-        verbatimTextOutput("expr"),
-        dataTableOutput("data")
-      ),
-      encoding = tagList(
-        data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
-        data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
-      )
+
+ui <- fluidPage(
+  teal.widgets::standard_layout(
+    output = div(
+      verbatimTextOutput("expr"),
+      dataTableOutput("data")
+    ),
+    encoding = tagList(
+      data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
+      data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
     )
-  ),
-  server = function(input, output, session) {
-    data_q <- teal.code::qenv()
-
-    data_q <- teal.code::eval_code(
-      data_q,
-      "ADSL <- data.frame(
-        STUDYID = 'A',
-        USUBJID = LETTERS[1:10],
-        SEX = rep(c('F', 'M'), 5),
-        AGE = rpois(10, 30),
-        BMRKR1 = rlnorm(10)
-      )"
-    )
-
-    data_q <- teal.code::eval_code(
-      data_q,
-      "ADLB <- expand.grid(
-        STUDYID = 'A',
-        USUBJID = LETTERS[1:10],
-        PARAMCD = c('ALT', 'CRP', 'IGA'),
-        AVISIT = c('SCREENING', 'BASELINE', 'WEEK 1 DAY 8', 'WEEK 2 DAY 15'),
-        AVAL = rlnorm(120),
-        CHG = rlnorm(120)
-       )"
-    )
-
-    merged_data <- merge_expression_module(
-      data_extract = list(adsl_var = adsl_extract, adlb_var = adlb_extract),
-      datasets = data_list,
-      join_keys = join_keys,
-      merge_function = "dplyr::left_join"
-    )
-
-    code_merge <- reactive({
-      for (exp in merged_data()$expr) data_q <- teal.code::eval_code(data_q, exp)
-      data_q
-    })
-
-    output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
-    output$data <- renderDataTable(code_merge()[["ANL"]])
-  }
+  )
 )
+
+server <- function(input, output, session) {
+  data_q <- teal.code::qenv()
+
+  data_q <- teal.code::eval_code(
+    data_q,
+    "ADSL <- data.frame(
+      STUDYID = 'A',
+      USUBJID = LETTERS[1:10],
+      SEX = rep(c('F', 'M'), 5),
+      AGE = rpois(10, 30),
+      BMRKR1 = rlnorm(10)
+    )"
+  )
+
+  data_q <- teal.code::eval_code(
+    data_q,
+    "ADLB <- expand.grid(
+      STUDYID = 'A',
+      USUBJID = LETTERS[1:10],
+      PARAMCD = c('ALT', 'CRP', 'IGA'),
+      AVISIT = c('SCREENING', 'BASELINE', 'WEEK 1 DAY 8', 'WEEK 2 DAY 15'),
+      AVAL = rlnorm(120),
+      CHG = rlnorm(120)
+     )"
+  )
+
+  merged_data <- merge_expression_module(
+    data_extract = list(adsl_var = adsl_extract, adlb_var = adlb_extract),
+    datasets = data_list,
+    join_keys = join_keys,
+    merge_function = "dplyr::left_join"
+  )
+
+  code_merge <- reactive({
+    for (exp in merged_data()$expr) data_q <- teal.code::eval_code(data_q, exp)
+    data_q
+  })
+
+  output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
+  output$data <- renderDataTable(code_merge()[["ANL"]])
+}
+
 \dontrun{
-shinyApp(app$ui, app$server)
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/merge_expression_srv.Rd
+++ b/man/merge_expression_srv.Rd
@@ -121,67 +121,67 @@ adlb_extract <- data_extract_spec(
   )
 )
 
-app <- shinyApp(
-  ui = fluidPage(
-    teal.widgets::standard_layout(
-      output = div(
-        verbatimTextOutput("expr"),
-        dataTableOutput("data")
-      ),
-      encoding = tagList(
-        data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
-        data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
-      )
+ui <- fluidPage(
+  teal.widgets::standard_layout(
+    output = div(
+      verbatimTextOutput("expr"),
+      dataTableOutput("data")
+    ),
+    encoding = tagList(
+      data_extract_ui("adsl_var", label = "ADSL selection", adsl_extract),
+      data_extract_ui("adlb_var", label = "ADLB selection", adlb_extract)
     )
-  ),
-  server = function(input, output, session) {
-    data_q <- teal.code::qenv()
-
-    data_q <- teal.code::eval_code(
-      data_q,
-      "ADSL <- data.frame(
-        STUDYID = 'A',
-        USUBJID = LETTERS[1:10],
-        SEX = rep(c('F', 'M'), 5),
-        AGE = rpois(10, 30),
-        BMRKR1 = rlnorm(10)
-      )"
-    )
-
-    data_q <- teal.code::eval_code(
-      data_q,
-      "ADLB <- expand.grid(
-        STUDYID = 'A',
-        USUBJID = LETTERS[1:10],
-        PARAMCD = c('ALT', 'CRP', 'IGA'),
-        AVISIT = c('SCREENING', 'BASELINE', 'WEEK 1 DAY 8', 'WEEK 2 DAY 15'),
-        AVAL = rlnorm(120),
-        CHG = rlnorm(120)
-      )"
-    )
-
-    selector_list <- data_extract_multiple_srv(
-      list(adsl_var = adsl_extract, adlb_var = adlb_extract),
-      datasets = data_list
-    )
-    merged_data <- merge_expression_srv(
-      selector_list = selector_list,
-      datasets = data_list,
-      join_keys = join_keys,
-      merge_function = "dplyr::left_join"
-    )
-
-    code_merge <- reactive({
-      for (exp in merged_data()$expr) data_q <- teal.code::eval_code(data_q, exp)
-      data_q
-    })
-
-    output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
-    output$data <- renderDataTable(code_merge()[["ANL"]])
-  }
+  )
 )
+
+server <- function(input, output, session) {
+  data_q <- teal.code::qenv()
+
+  data_q <- teal.code::eval_code(
+    data_q,
+    "ADSL <- data.frame(
+      STUDYID = 'A',
+      USUBJID = LETTERS[1:10],
+      SEX = rep(c('F', 'M'), 5),
+      AGE = rpois(10, 30),
+      BMRKR1 = rlnorm(10)
+    )"
+  )
+
+  data_q <- teal.code::eval_code(
+    data_q,
+    "ADLB <- expand.grid(
+      STUDYID = 'A',
+      USUBJID = LETTERS[1:10],
+      PARAMCD = c('ALT', 'CRP', 'IGA'),
+      AVISIT = c('SCREENING', 'BASELINE', 'WEEK 1 DAY 8', 'WEEK 2 DAY 15'),
+      AVAL = rlnorm(120),
+      CHG = rlnorm(120)
+    )"
+  )
+
+  selector_list <- data_extract_multiple_srv(
+    list(adsl_var = adsl_extract, adlb_var = adlb_extract),
+    datasets = data_list
+  )
+  merged_data <- merge_expression_srv(
+    selector_list = selector_list,
+    datasets = data_list,
+    join_keys = join_keys,
+    merge_function = "dplyr::left_join"
+  )
+
+  code_merge <- reactive({
+    for (exp in merged_data()$expr) data_q <- teal.code::eval_code(data_q, exp)
+    data_q
+  })
+
+  output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
+  output$data <- renderDataTable(code_merge()[["ANL"]])
+}
+
 \dontrun{
-shinyApp(app$ui, app$server)
+shinyApp(ui, server)
 }
 }
 \seealso{

--- a/man/resolve.Rd
+++ b/man/resolve.Rd
@@ -23,9 +23,9 @@ Resolved object.
 \examples{
 ADSL <- rADSL
 attr(ADSL, "keys") <- c("STUDYID", "USUBJID")
-data_list <- list(ADSL = reactive(ADSL))
+data_list <- list(ADSL = shiny::reactive(ADSL))
 keys <- list(ADSL = attr(ADSL, "keys"))
-isolate({
+shiny::isolate({
   # value_choices example
   v1 <- value_choices("ADSL", "SEX", "SEX")
   v1

--- a/man/resolve.Rd
+++ b/man/resolve.Rd
@@ -21,11 +21,11 @@ Resolved object.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \examples{
-ADSL <- teal.transform::rADSL
+ADSL <- rADSL
 attr(ADSL, "keys") <- c("STUDYID", "USUBJID")
-data_list <- list(ADSL = shiny::reactive(ADSL))
+data_list <- list(ADSL = reactive(ADSL))
 keys <- list(ADSL = attr(ADSL, "keys"))
-shiny::isolate({
+isolate({
   # value_choices example
   v1 <- value_choices("ADSL", "SEX", "SEX")
   v1

--- a/man/resolve_delayed.Rd
+++ b/man/resolve_delayed.Rd
@@ -22,8 +22,8 @@ Resolved object.
 }
 \examples{
 ADSL <- rADSL
-isolate({
-  data_list <- list(ADSL = reactive(ADSL))
+shiny::isolate({
+  data_list <- list(ADSL = shiny::reactive(ADSL))
 
   # value_choices example
   v1 <- value_choices("ADSL", "SEX", "SEX")

--- a/man/resolve_delayed.Rd
+++ b/man/resolve_delayed.Rd
@@ -21,9 +21,9 @@ Resolved object.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \examples{
-ADSL <- teal.transform::rADSL
-shiny::isolate({
-  data_list <- list(ADSL = shiny::reactive(ADSL))
+ADSL <- rADSL
+isolate({
+  data_list <- list(ADSL = reactive(ADSL))
 
   # value_choices example
   v1 <- value_choices("ADSL", "SEX", "SEX")

--- a/man/value_choices.Rd
+++ b/man/value_choices.Rd
@@ -36,7 +36,7 @@ named character vector or \code{delayed_data} object
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \examples{
-ADRS <- teal.transform::rADRS
+ADRS <- rADRS
 value_choices(ADRS, "PARAMCD", "PARAM", subset = c("BESRSPI", "INVET"))
 value_choices(ADRS, c("PARAMCD", "ARMCD"), c("PARAM", "ARM"))
 value_choices(ADRS, c("PARAMCD", "ARMCD"), c("PARAM", "ARM"),

--- a/man/variable_choices.Rd
+++ b/man/variable_choices.Rd
@@ -38,7 +38,7 @@ named character vector with additional attributes or \code{delayed_data} object
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \examples{
-ADRS <- teal.transform::rADRS
+ADRS <- rADRS
 variable_choices(ADRS)
 variable_choices(ADRS, subset = c("PARAM", "PARAMCD"))
 variable_choices(ADRS, subset = c("", "PARAM", "PARAMCD"))

--- a/tests/testthat/setup-logger.R
+++ b/tests/testthat/setup-logger.R
@@ -1,0 +1,1 @@
+logger::log_appender(function(...) NULL, namespace = "teal.transform")

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -1,0 +1,17 @@
+opts_partial_match_old <- list(
+  warnPartialMatchDollar = getOption("warnPartialMatchDollar"),
+  warnPartialMatchArgs = getOption("warnPartialMatchArgs"),
+  warnPartialMatchAttr = getOption("warnPartialMatchAttr")
+)
+opts_partial_match_new <- list(
+  warnPartialMatchDollar = TRUE,
+  warnPartialMatchArgs = TRUE,
+  warnPartialMatchAttr = TRUE
+)
+
+if (isFALSE(getFromNamespace("on_cran", "testthat")()) && require("withr")) {
+  withr::local_options(
+    opts_partial_match_new,
+    .local_envir = testthat::teardown_env()
+  )
+}

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -9,7 +9,7 @@ opts_partial_match_new <- list(
   warnPartialMatchAttr = TRUE
 )
 
-if (isFALSE(getFromNamespace("on_cran", "testthat")()) && require("withr")) {
+if (isFALSE(getFromNamespace("on_cran", "testthat")()) && requireNamespace("withr", quietly = TRUE)) {
   withr::local_options(
     opts_partial_match_new,
     .local_envir = testthat::teardown_env()

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -1,3 +1,6 @@
+# `opts_partial_match_old` is left for exclusions due to partial matching in dependent packages (i.e. not fixable here)
+# it might happen that it is not used right now, but it is left for possible future use
+# use with: `withr::with_options(opts_partial_match_old, { ... })` inside the test
 opts_partial_match_old <- list(
   warnPartialMatchDollar = getOption("warnPartialMatchDollar"),
   warnPartialMatchArgs = getOption("warnPartialMatchArgs"),

--- a/tests/testthat/test-data_extract_module.R
+++ b/tests/testthat/test-data_extract_module.R
@@ -1,5 +1,5 @@
-ADLB <- teal.transform::rADLB # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADLB <- rADLB # nolint
+ADTTE <- rADTTE # nolint
 
 testthat::test_that("Single filter", {
   data_extract <- data_extract_spec(

--- a/tests/testthat/test-data_extract_multiple_srv.R
+++ b/tests/testthat/test-data_extract_multiple_srv.R
@@ -1,6 +1,6 @@
-ADSL <- teal.transform::rADSL # nolint
-ADLB <- teal.transform::rADLB # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL # nolint
+ADLB <- rADLB # nolint
+ADTTE <- rADTTE # nolint
 
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE), ADLB = reactive(ADLB))
 join_keys <- teal.data::default_cdisc_join_keys[c("ADSL", "ADTTE", "ADLB")]

--- a/tests/testthat/test-data_extract_spec.R
+++ b/tests/testthat/test-data_extract_spec.R
@@ -199,8 +199,8 @@ testthat::test_that("delayed data_extract_spec works", {
   testthat::expect_identical(expected_spec, mix3_res)
 })
 
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL # nolint
+ADTTE <- rADTTE # nolint
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE))
 key_list <- list(ADSL = c("STUDYID", "USUBJID"), ADTTE = c("STUDYID", "USUBJID", "PARAMCD"))
 

--- a/tests/testthat/test-data_extract_srv.R
+++ b/tests/testthat/test-data_extract_srv.R
@@ -1,6 +1,6 @@
-ADSL <- teal.transform::rADSL # nolint
-ADLB <- teal.transform::rADLB # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL # nolint
+ADLB <- rADLB # nolint
+ADTTE <- rADTTE # nolint
 
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE), ADLB = reactive(ADLB))
 join_keys <- teal.data::default_cdisc_join_keys[c("ADSL", "ADTTE", "ADLB")]

--- a/tests/testthat/test-delayed_data_extract.R
+++ b/tests/testthat/test-delayed_data_extract.R
@@ -1,9 +1,9 @@
 # Contains integration tests between delayed data loading objects and
 # the objects responsible for loading, pulling and filtering the data
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
-ADAE <- teal.transform::rADAE # nolint
-ADRS <- teal.transform::rADRS # nolint
+ADSL <- rADSL # nolint
+ADTTE <- rADTTE # nolint
+ADAE <- rADAE # nolint
+ADRS <- rADRS # nolint
 
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE), ADAE = reactive(ADAE), ADRS = reactive(ADRS))
 join_keys <- teal.data::default_cdisc_join_keys[c("ADSL", "ADTTE", "ADAE", "ADRS")]

--- a/tests/testthat/test-dplyr_call_examples.R
+++ b/tests/testthat/test-dplyr_call_examples.R
@@ -3361,7 +3361,7 @@ testthat::test_that("Universal example", {
   merged_datasets <- isolate(
     merge_datasets(
       selector_list = selector_list,
-      dataset = data_list,
+      datasets = data_list,
       join_keys = join_keys,
       merge_function = "dplyr::left_join",
       anl_name = "ANL"

--- a/tests/testthat/test-filter_spec.R
+++ b/tests/testthat/test-filter_spec.R
@@ -1,5 +1,5 @@
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL # nolint
+ADTTE <- rADTTE # nolint
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE), ADLB = reactive(ADLB))
 join_keys <- teal.data::default_cdisc_join_keys[c("ADSL", "ADTTE", "ADLB")]
 primary_keys_list <- lapply(join_keys, function(x) x[[1]])
@@ -218,7 +218,7 @@ testthat::test_that("filter_spec_internal", {
 })
 
 testthat::test_that("filter_spec_internal contains dataname", {
-  ADSL <- teal.transform::rADSL # nolint
+  ADSL <- rADSL # nolint
 
   x_filter <- filter_spec_internal(
     vars_choices = variable_choices(ADSL)
@@ -354,7 +354,7 @@ testthat::test_that("delayed version of filter_spec", {
     )
   )
 
-  res_obj <- isolate(resolve(obj, datasets = data_list, key = primary_keys_list))
+  res_obj <- isolate(resolve(obj, datasets = data_list, keys = primary_keys_list))
   exp_obj <- filter_spec(
     vars = variable_choices(ADSL, subset = "ARMCD"),
     choices = value_choices(ADSL, var_choices = "ARMCD", var_label = "ARM", subset = c("ARM A", "ARM B")),
@@ -426,7 +426,7 @@ testthat::test_that("delayed version of filter_spec", {
     )
   )
 
-  res_obj <- isolate(resolve(obj, datasets = data_list, key = primary_keys_list))
+  res_obj <- isolate(resolve(obj, datasets = data_list, keys = primary_keys_list))
 
   # comparison not implemented, must be done individually
   testthat::expect_equal(res_obj$choices, exp_obj$choices)

--- a/tests/testthat/test-get_filter_call-datasets.R
+++ b/tests/testthat/test-get_filter_call-datasets.R
@@ -20,7 +20,7 @@ testthat::test_that("get_filter_call throws error if dataset is not a named list
   testthat::expect_error(
     get_filter_call(filter = list(
       list(columns = "SEX", selected = list(NA))
-    ), dataname = "ADAMSET", data = list(ADAMSET = data_small)),
+    ), dataname = "ADAMSET", datasets = list(ADAMSET = data_small)),
     "May only contain the following types: {reactive}, but element 1 has type 'data.frame'.",
     fixed = TRUE
   )
@@ -30,7 +30,7 @@ testthat::test_that("get_filter_call - data - NAs and one column - one selection
   testthat::expect_equal(
     isolate(get_filter_call(filter = list(
       list(columns = "SEX", selected = list(NA))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter(is.na(SEX))
     )
@@ -41,7 +41,7 @@ testthat::test_that("get_filter_call - data - NAs and one column - two selection
   testthat::expect_equal(
     isolate(get_filter_call(filter = list(
       list(columns = "SEX", selected = list(NA, "F"))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter(SEX %in% c(NA_character_, "F"))
     )
@@ -52,7 +52,7 @@ testthat::test_that("get_filter_call - data - NAs and two columns", {
   testthat::expect_equal(
     isolate(get_filter_call(filter = list(
       list(columns = c("SEX", "AGE"), selected = list(c("F", "44"), c(NA, "33")))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter((SEX == "F" & AGE == "44") | (is.na(SEX) & AGE == "33"))
     )
@@ -64,7 +64,7 @@ testthat::test_that("get_filter_call - data - some of factor levels and integer"
     isolate(get_filter_call(filter = list(
       list(columns = "SEX", selected = list("F")),
       list(columns = "AGE", selected = list("42", "35"))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter(SEX == "F" & AGE %in% c("42", "35"))
     )
@@ -75,7 +75,7 @@ testthat::test_that("get_filter_call - data - trunc POSIX and single column", {
   testthat::expect_equal(
     isolate(get_filter_call(filter = list(
       list(columns = "TRTSDTM", selected = list("2020-03-08 06:28:11"))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter(trunc(TRTSDTM) == "2020-03-08 06:28:11")
     )
@@ -89,7 +89,7 @@ testthat::test_that("get_filter_call - data - trunc POSIX and two columns", {
         c("2020-03-08 06:28:11", "33"),
         c("2020-03-09 06:28:11", NA)
       ))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter(
         (trunc(TRTSDTM) == "2020-03-08 06:28:11" & AGE == "33") |
@@ -106,7 +106,7 @@ testthat::test_that("get_filter_call - data - SEX and two columns, SEX variable 
         c("F", "33"),
         c("M", NA)
       ))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter((SEX == "F" & AGE == "33") | (SEX == "M" & is.na(AGE)))
     )
@@ -120,7 +120,7 @@ testthat::test_that("get_filter_call - data - three columns", {
         c("F", "33", NA),
         c("M", NA, NA)
       ))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter((SEX == "F" & AGE == "33" & is.na(DCSREAS)) | (SEX == "M" & is.na(AGE) & is.na(DCSREAS)))
     )
@@ -134,7 +134,7 @@ testthat::test_that("get_filter_call - data - non empty filter as NA is not sele
         "ADVERSE EVENT",
         "DEATH"
       ))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(dplyr::filter(DCSREAS %in% c("ADVERSE EVENT", "DEATH")))
   )
 })
@@ -146,7 +146,7 @@ testthat::test_that("get_filter_call - FALSE if empty selection for single", {
         list(columns = "DCSREAS", selected = c())
       ),
       dataname = "ADAMSET",
-      data = data_list
+      datasets = data_list
     )),
     quote(dplyr::filter(FALSE))
   )
@@ -157,7 +157,7 @@ testthat::test_that("get_filter_call - data - all factor levels and integer", {
     isolate(get_filter_call(filter = list(
       list(columns = "SEX", selected = list("F", "M")),
       list(columns = "AGE", selected = list("42", "35"))
-    ), dataname = "ADAMSET", data = data_list)),
+    ), dataname = "ADAMSET", datasets = data_list)),
     quote(
       dplyr::filter(AGE %in% c("42", "35"))
     )
@@ -168,14 +168,14 @@ testthat::test_that("get_filter_call - data - empty filter as all levels and NA 
   testthat::expect_null(
     isolate(get_filter_call(filter = list(
       list(columns = "DCSREAS", selected = c("ADVERSE EVENT", "DEATH", NA))
-    ), dataname = "ADAMSET", data = data_list))
+    ), dataname = "ADAMSET", datasets = data_list))
   )
 })
 testthat::test_that("get_filter_call - data - empty as all levels for SEX are selected - no missings", {
   testthat::expect_null(
     isolate(get_filter_call(filter = list(
       list(columns = "SEX", selected = list("F", "M"))
-    ), dataname = "ADAMSET", data = data_list))
+    ), dataname = "ADAMSET", datasets = data_list))
   )
 })
 
@@ -189,7 +189,7 @@ testthat::test_that("get_filter_call - skip if all selected for single variable"
         )
       ),
       dataname = "ADAMSET",
-      data = data_list
+      datasets = data_list
     ))
   )
 })
@@ -204,7 +204,7 @@ testthat::test_that("get_filter_call - skip if all selected for multiple variabl
         )
       ),
       dataname = "ADAMSET",
-      data = data_list
+      datasets = data_list
     ))
   )
 })
@@ -219,7 +219,7 @@ testthat::test_that("get_filter_call - skip if all selected for multiple variabl
         )
       ),
       dataname = "ADAMSET",
-      data = data_list
+      datasets = data_list
     ))
   )
 })

--- a/tests/testthat/test-resolve.R
+++ b/tests/testthat/test-resolve.R
@@ -1,5 +1,5 @@
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL # nolint
+ADTTE <- rADTTE # nolint
 
 arm_ref_comp <- list(
   ARMCD = list(

--- a/tests/testthat/test-resolve_delayed.R
+++ b/tests/testthat/test-resolve_delayed.R
@@ -1,5 +1,5 @@
-adsl <- teal.transform::rADSL # nolint
-adtte <- teal.transform::rADTTE # nolint
+adsl <- rADSL # nolint
+adtte <- rADTTE # nolint
 
 data_list <- list(ADSL = reactive(adsl), ADTTE = reactive(adtte))
 join_keys <- teal.data::default_cdisc_join_keys[c("ADSL", "ADTTE")]
@@ -150,14 +150,12 @@ testthat::test_that("resolving delayed choices removes selected not in choices a
     selected = variable_choices("IRIS", c("Petal.Length", "Sepal.Width"))
   )
 
-  output <- testthat::capture_output({
-    shiny::isolate({
+  testthat::expect_warning(
+    output <- shiny::isolate({
       resolved_cs <- resolve_delayed(c_s, datasets = list(IRIS = reactive(iris)))
-    })
-  })
+    }),
+    "Removing Petal.Length from 'selected' as not in 'choices' when resolving delayed choices_selected"
+  )
 
   testthat::expect_equal(resolved_cs$selected, stats::setNames("Sepal.Width", "Sepal.Width: Sepal.Width"))
-  testthat::expect_true(
-    grepl("Removing Petal.Length from 'selected' as not in 'choices' when resolving delayed choices_selected", output)
-  )
 })

--- a/tests/testthat/test-select_spec.R
+++ b/tests/testthat/test-select_spec.R
@@ -1,5 +1,5 @@
-adsl <- teal.transform::rADSL # nolint
-adtte <- teal.transform::rADTTE # nolint
+adsl <- rADSL # nolint
+adtte <- rADTTE # nolint
 data_list <- list(ADSL = reactive(adsl), ADTTE = reactive(adtte))
 primary_keys_list <- list(ADSL = c("STUDYID", "USUBJID"), ADTTE = c("STUDYID", "USUBJID", "PARAMCD"))
 

--- a/tests/testthat/test-value_choices.R
+++ b/tests/testthat/test-value_choices.R
@@ -1,5 +1,5 @@
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL # nolint
+ADTTE <- rADTTE # nolint
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE))
 primary_keys_list <- list(ADSL = c("STUDYID", "USUBJID"), ADTTE = c("STUDYID", "USUBJID", "PARAMCD"))
 

--- a/tests/testthat/test-variable_choices.R
+++ b/tests/testthat/test-variable_choices.R
@@ -1,5 +1,5 @@
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL # nolint
+ADTTE <- rADTTE # nolint
 data_list <- list(ADSL = reactive(ADSL), ADTTE = reactive(ADTTE))
 primary_keys_list <- list(ADSL = c("STUDYID", "USUBJID"), ADTTE = c("STUDYID", "USUBJID", "PARAMCD"))
 

--- a/vignettes/data-extract-merge.Rmd
+++ b/vignettes/data-extract-merge.Rmd
@@ -32,7 +32,7 @@ In the following code block we create a `data_extract_spec` object per dataset a
 library(teal.transform)
 library(shiny)
 
-adsl_extract <- teal.transform::data_extract_spec(
+adsl_extract <- data_extract_spec(
   dataname = "ADSL",
   select = select_spec(
     label = "Select variable:",
@@ -43,7 +43,7 @@ adsl_extract <- teal.transform::data_extract_spec(
   )
 )
 
-adtte_extract <- teal.transform::data_extract_spec(
+adtte_extract <- data_extract_spec(
   dataname = "ADTTE",
   select = select_spec(
     choices = c("AVAL", "ASEQ"),
@@ -75,12 +75,12 @@ merge_ui <- function(id, data_extracts) {
       dataTableOutput(ns("data"))
     ),
     encoding = div(
-      teal.transform::data_extract_ui(
+      data_extract_ui(
         ns("adsl_extract"), # must correspond with data_extracts list names
         label = "ADSL extract",
         data_extracts[[1]]
       ),
-      teal.transform::data_extract_ui(
+      data_extract_ui(
         ns("adtte_extract"), # must correspond with data_extracts list names
         label = "ADTTE extract",
         data_extracts[[2]]
@@ -91,14 +91,14 @@ merge_ui <- function(id, data_extracts) {
 
 merge_srv <- function(id, datasets, data_extracts, join_keys) {
   moduleServer(id, function(input, output, session) {
-    selector_list <- teal.transform::data_extract_multiple_srv(data_extracts, datasets, join_keys)
-    merged_data <- teal.transform::merge_expression_srv(
+    selector_list <- data_extract_multiple_srv(data_extracts, datasets, join_keys)
+    merged_data <- merge_expression_srv(
       selector_list = selector_list,
       datasets = datasets,
       join_keys = join_keys,
       merge_function = "dplyr::left_join"
     )
-    ANL <- reactive({ # nolint
+    ANL <- reactive({
       eval(envir = list2env(datasets), expr = as.expression(merged_data()$expr))
     })
     output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
@@ -112,15 +112,15 @@ Output from `data_extract_srv` (`reactive`) should be passed to `merge_expressio
 
 #### Example data
 
-`data_extract_srv` module depends on either a list of reactive or non-reactive `data.frame` objects. Here, we show the 
+`data_extract_srv` module depends on either a list of reactive or non-reactive `data.frame` objects. Here, we show the
 usage of a list of `data.frame` objects as input to `datasets`
 where a list of necessary join keys per `data.frame` object is required:
 
 
 ```{r}
 # Define data.frame objects
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL
+ADTTE <- rADTTE
 
 # create a list of data.frame objects
 datasets <- list(ADSL = ADSL, ADTTE = ADTTE)

--- a/vignettes/data-extract.Rmd
+++ b/vignettes/data-extract.Rmd
@@ -72,8 +72,8 @@ where a list of necessary join keys per `data.frame` object is required:
 
 ```{r}
 # Define data.frame objects
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL
+ADTTE <- rADTTE
 
 # create a list of data.frame objects
 datasets <- list(ADSL = ADSL, ADTTE = ADTTE)

--- a/vignettes/data-merge.Rmd
+++ b/vignettes/data-merge.Rmd
@@ -36,7 +36,7 @@ corresponding to every `data.frame` object.
 library(teal.transform)
 library(shiny)
 
-adsl_extract <- teal.transform::data_extract_spec(
+adsl_extract <- data_extract_spec(
   dataname = "ADSL",
   select = select_spec(
     label = "Select variable:",
@@ -47,7 +47,7 @@ adsl_extract <- teal.transform::data_extract_spec(
   )
 )
 
-adtte_extract <- teal.transform::data_extract_spec(
+adtte_extract <- data_extract_spec(
   dataname = "ADTTE",
   select = select_spec(
     choices = c("AVAL", "ASEQ"),
@@ -67,12 +67,12 @@ merge_ui <- function(id, data_extracts) {
       dataTableOutput(ns("data"))
     ),
     encoding = div(
-      teal.transform::data_extract_ui(
+      data_extract_ui(
         ns("adsl_extract"), # must correspond with data_extracts list names
         label = "ADSL extract",
         data_extracts[[1]]
       ),
-      teal.transform::data_extract_ui(
+      data_extract_ui(
         ns("adtte_extract"), # must correspond with data_extracts list names
         label = "ADTTE extract",
         data_extracts[[2]]
@@ -83,14 +83,14 @@ merge_ui <- function(id, data_extracts) {
 
 merge_module <- function(id, datasets, data_extracts, join_keys) {
   moduleServer(id, function(input, output, session) {
-    merged_data <- teal.transform::merge_expression_module(
+    merged_data <- merge_expression_module(
       data_extract = data_extracts,
       datasets = datasets,
       join_keys = join_keys,
       merge_function = "dplyr::left_join"
     )
 
-    ANL <- reactive({ # nolint
+    ANL <- reactive({
       eval(envir = list2env(datasets), expr = as.expression(merged_data()$expr))
     })
     output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))
@@ -99,8 +99,8 @@ merge_module <- function(id, datasets, data_extracts, join_keys) {
 }
 
 # Define data.frame objects
-ADSL <- teal.transform::rADSL # nolint
-ADTTE <- teal.transform::rADTTE # nolint
+ADSL <- rADSL
+ADTTE <- rADTTE
 
 # create a list of data.frame objects
 datasets <- list(ADSL = ADSL, ADTTE = ADTTE)
@@ -131,7 +131,7 @@ In the scenario above, if the user deselects the `ADTTE` variable, the merging b
 ```{r}
 merge_module <- function(id, datasets, data_extracts, join_keys) {
   moduleServer(id, function(input, output, session) {
-    selector_list <- teal.transform::data_extract_multiple_srv(data_extracts, datasets, join_keys)
+    selector_list <- data_extract_multiple_srv(data_extracts, datasets, join_keys)
     reactive_selector_list <- reactive({
       if (is.null(selector_list()$adtte_extract) || length(selector_list()$adtte_extract()$select) == 0) {
         selector_list()[names(selector_list()) != "adtte_extract"]
@@ -140,14 +140,14 @@ merge_module <- function(id, datasets, data_extracts, join_keys) {
       }
     })
 
-    merged_data <- teal.transform::merge_expression_srv(
+    merged_data <- merge_expression_srv(
       selector_list = reactive_selector_list,
       datasets = datasets,
       join_keys = join_keys,
       merge_function = "dplyr::left_join"
     )
 
-    ANL <- reactive({ # nolint
+    ANL <- reactive({
       eval(envir = list2env(datasets), expr = as.expression(merged_data()$expr))
     })
     output$expr <- renderText(paste(merged_data()$expr, collapse = "\n"))


### PR DESCRIPTION
- part of https://github.com/insightsengineering/coredev-tasks/issues/498
- part of https://github.com/insightsengineering/coredev-tasks/issues/478
  - please read this for more info about the implementation: https://github.com/insightsengineering/coredev-tasks/issues/478#issuecomment-1909912778
- update `Config/Needs/verdepcheck` entries
- reviewed all `dontrun{}`
- removed `teal.transform::` from examples as this is redundant
- removed `teal.transform::` from code (incl. examples) as this is redundant
- removed `pkg::` from examples & vignettes if pkg had been previously loaded
- removed empty first line from examples as this is actually being rendered
- fixed app example(s) - errors when `app <- shinyApp(...); shinyApp(app)`
- removed `# nolint` from vignette knitr chunks (this is actually rendered!). I needed to put a higher level exclusion in the top `.lintr` file to silent lint errors. This is of course more powerful than single line (or code-block) exclusions