### PR TITLE
Replace `is.atomic` calls with checkmate equivalents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1

--- a/R/choices_selected.R
+++ b/R/choices_selected.R
@@ -130,10 +130,8 @@ choices_selected <- function(choices,
     checkmate::check_atomic(selected),
     checkmate::check_multi_class(selected, c("delayed_data", "all_choices"))
   )
-  checkmate::assert(
-    checkmate::check_flag(keep_order),
-    checkmate::check_flag(fixed)
-  )
+  checkmate::assert_flag(keep_order)
+  checkmate::assert_flag(fixed)
 
   if (inherits(selected, "all_choices")) selected <- choices
 

--- a/R/choices_selected.R
+++ b/R/choices_selected.R
@@ -122,10 +122,18 @@ choices_selected <- function(choices,
                              selected = if (inherits(choices, "delayed_data")) NULL else choices[1],
                              keep_order = FALSE,
                              fixed = FALSE) {
-  stopifnot(is.atomic(choices) || inherits(choices, "delayed_data"))
-  stopifnot(is.atomic(selected) || inherits(selected, "delayed_data") || inherits(selected, "all_choices"))
-  checkmate::assert_flag(keep_order)
-  checkmate::assert_flag(fixed)
+  checkmate::assert(
+    checkmate::check_atomic(choices),
+    checkmate::check_class(choices, "delayed_data")
+  )
+  checkmate::assert(
+    checkmate::check_atomic(selected),
+    checkmate::check_multi_class(selected, c("delayed_data", "all_choices"))
+  )
+  checkmate::assert(
+    checkmate::check_flag(keep_order),
+    checkmate::check_flag(fixed)
+  )
 
   if (inherits(selected, "all_choices")) selected <- choices
 
@@ -223,7 +231,7 @@ no_selected_as_NULL <- function(x) { # nolint
 ## Non-exported utils functions ----
 ## Modify vectors and keep attributes
 vector_reorder <- function(vec, idx) {
-  stopifnot(is.atomic(vec))
+  checkmate::assert_atomic(vec)
   checkmate::assert_integer(idx, min.len = 1, lower = 1, any.missing = FALSE)
   stopifnot(length(vec) == length(idx))
 
@@ -243,7 +251,7 @@ vector_reorder <- function(vec, idx) {
 }
 
 vector_pop <- function(vec, idx) {
-  stopifnot(is.atomic(vec))
+  checkmate::assert_atomic(vec)
   checkmate::assert_integer(idx, lower = 1, any.missing = FALSE)
 
   if (length(idx) == 0) {
@@ -265,7 +273,7 @@ vector_pop <- function(vec, idx) {
 }
 
 vector_remove_dups <- function(vec) {
-  stopifnot(is.atomic(vec))
+  checkmate::assert_atomic(vec)
 
   idx <- which(duplicated(vec))
 

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -201,7 +201,7 @@ resolve_delayed_expr <- function(x, ds, is_value_choices) {
 
   # check returned value
   if (is_value_choices) {
-    if (!isTRUE(checkmate::check_atomic(res)) || anyDuplicated(res)) {
+    if (!isTRUE(checkmate::test_atomic(res)) || anyDuplicated(res)) {
       stop(paste(
         "The following function must return a vector with unique values",
         "from the respective columns of the dataset.\n\n",

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -201,7 +201,7 @@ resolve_delayed_expr <- function(x, ds, is_value_choices) {
 
   # check returned value
   if (is_value_choices) {
-    if (!is.atomic(res) || anyDuplicated(res)) {
+    if (!isTRUE(checkmate::check_atomic(res)) || anyDuplicated(res)) {
       stop(paste(
         "The following function must return a vector with unique values",
         "from the respective columns of the dataset.\n\n",

--- a/R/resolve.R
+++ b/R/resolve.R
@@ -201,7 +201,7 @@ resolve_delayed_expr <- function(x, ds, is_value_choices) {
 
   # check returned value
   if (is_value_choices) {
-    if (!isTRUE(checkmate::test_atomic(res)) || anyDuplicated(res)) {
+    if (!checkmate::test_atomic(res) || anyDuplicated(res)) {
       stop(paste(
         "The following function must return a vector with unique values",
         "from the respective columns of the dataset.\n\n",

--- a/R/select_spec.R
+++ b/R/select_spec.R
@@ -119,8 +119,16 @@ select_spec.delayed_data <- function(choices, # nolint
                                      always_selected = NULL,
                                      ordered = FALSE,
                                      label = NULL) {
-  stopifnot(is.null(selected) || is.atomic(selected) || inherits(selected, "delayed_data"))
-  stopifnot(is.null(choices) || is.atomic(choices) || inherits(choices, "delayed_data"))
+  checkmate::assert(
+    checkmate::check_null(selected),
+    checkmate::check_atomic(selected),
+    checkmate::check_class(selected, "delayed_data")
+  )
+  checkmate::assert(
+    checkmate::check_null(choices),
+    checkmate::check_atomic(choices),
+    checkmate::check_class(choices, "delayed_data")
+  )
 
   structure(
     list(
@@ -145,8 +153,14 @@ select_spec.default <- function(choices, # nolint
                                 always_selected = NULL,
                                 ordered = FALSE,
                                 label = NULL) {
-  stopifnot(is.null(choices) || is.atomic(choices))
-  stopifnot(is.null(selected) || is.atomic(selected))
+  checkmate::assert(
+    checkmate::check_null(choices),
+    checkmate::check_atomic(choices)
+  )
+  checkmate::assert(
+    checkmate::check_null(selected),
+    checkmate::check_atomic(selected)
+  )
 
   # if names is NULL, shiny will put strange labels (with quotes etc.) in the selectInputs, so we set it to the values
   if (is.null(names(choices))) {
@@ -155,7 +169,7 @@ select_spec.default <- function(choices, # nolint
 
   # Deal with selected
   if (length(selected) > 0) {
-    stopifnot(is.atomic(selected))
+    checkmate::assert_atomic(selected)
     checkmate::assert_subset(selected, choices)
     stopifnot(multiple || length(selected) == 1)
     if (is.null(names(selected))) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,7 @@
 #' @param sep (`character`) Separator
 #' @export
 split_by_sep <- function(x, sep) {
-  stopifnot(is.atomic(x))
+  checkmate::assert_atomic(x)
   if (is.character(x)) {
     strsplit(x, sep, fixed = TRUE)
   } else {


### PR DESCRIPTION
Closes https://github.com/insightsengineering/coredev-tasks/issues/508

`is.atomic` breaks for the `NULL` input in R devel. However, checkmate retains the past behavior, so we should replace them when `NULL` is possible as inputs.