### PR TITLE
Fix the examples from the vignettes

### DIFF
--- a/R/get_dplyr_call.R
+++ b/R/get_dplyr_call.R
@@ -286,7 +286,7 @@ get_filter_call <- function(filter, dataname = NULL, datasets = NULL) {
       "{ paste(sapply(filter, function(x) x$columns), collapse = ', ') } filters."
     )
   )
-  checkmate::assert_list(datasets, types = "reactive", names = "named", null.ok = TRUE)
+  checkmate::assert_list(datasets, types = c("data.frame"), min.len = 1, names = "named")
   if (is.null(filter)) {
     return(NULL)
   }
@@ -303,7 +303,7 @@ get_filter_call <- function(filter, dataname = NULL, datasets = NULL) {
     }
 
     keys <- filter$columns
-    datas_vars <- if (!is.null(datasets)) datasets[[dataname]]() else NULL
+    datas_vars <- if (!is.null(datasets)) datasets[[dataname]] else NULL
 
     if (!is.null(datas_vars)) {
       u_variables <- unique(apply(datas_vars[, keys, drop = FALSE], 1, function(x) paste(x, collapse = "-")))

--- a/R/get_merge_call.R
+++ b/R/get_merge_call.R
@@ -360,8 +360,8 @@ get_anl_relabel_call <- function(columns_source, datasets, anl_name = "ANL") {
         }
 
         data_used <- datasets[[attr(selector, "dataname")]]
-        labels <- teal.data::col_labels(data_used(), fill = FALSE)
-        column_labels <- labels[intersect(colnames(data_used()), column_names)]
+        labels <- teal.data::col_labels(data_used, fill = FALSE)
+        column_labels <- labels[intersect(colnames(data_used), column_names)]
 
         # NULL for no labels at all, character(0) for no labels for a given columns
         return(


### PR DESCRIPTION
When you try to run the example code from the vignettes [Data Merge](https://insightsengineering.github.io/teal.transform/main/articles/data-merge.html) and [Combining Data Extract with Data Merge](https://insightsengineering.github.io/teal.transform/main/articles/data-extract-merge.html) you will realize that they are broken.

This small change fixes them. Presumably, this is because of the removal of the delayed data, causing the downstream dataset to be a non-reactive dataset instead of a reactive value.