### PR TITLE
use restoreInput in update functions

### DIFF
--- a/R/data_extract_filter_module.R
+++ b/R/data_extract_filter_module.R
@@ -66,6 +66,8 @@ data_extract_filter_srv <- function(id, datasets, filter) {
       force(filter)
       logger::log_trace("data_extract_filter_srv initialized with: { filter$dataname } dataset.")
 
+      ns <- session$ns
+
       isolate({
         # when the filter is initialized with a delayed spec, the choices and selected are NULL
         # here delayed are resolved and the values are set up
@@ -73,13 +75,13 @@ data_extract_filter_srv <- function(id, datasets, filter) {
           session = session,
           inputId = "col",
           choices = filter$vars_choices,
-          selected = filter$vars_selected
+          selected = shiny::restoreInput(ns("col"), filter$vars_selected)
         )
         teal.widgets::updateOptionalSelectInput(
           session = session,
           inputId = "vals",
           choices = filter$choices,
-          selected = filter$selected
+          selected = shiny::restoreInput(ns("vals"), filter$selected)
         )
       })
 
@@ -115,14 +117,17 @@ data_extract_filter_srv <- function(id, datasets, filter) {
             session = session,
             inputId = "vals",
             choices = paste0(input$val, "$_<-_random_text_to_ensure_val_will_be_different_from_previous"),
-            selected = paste0(input$val, "$_<-_random_text_to_ensure_val_will_be_different_from_previous")
+            selected = shiny::restoreInput(
+              ns("vals"),
+              paste0(input$val, "$_<-_random_text_to_ensure_val_will_be_different_from_previous")
+            )
           )
 
           teal.widgets::updateOptionalSelectInput(
             session = session,
             inputId = "vals",
             choices = choices,
-            selected = selected
+            selected = shiny::restoreInput(ns("vals"), selected)
           )
         }
       )

--- a/R/data_extract_single_module.R
+++ b/R/data_extract_single_module.R
@@ -78,6 +78,8 @@ data_extract_single_srv <- function(id, datasets, single_data_extract_spec) {
     function(input, output, session) {
       logger::log_trace("data_extract_single_srv initialized with dataset: { single_data_extract_spec$dataname }.")
 
+      ns <- session$ns
+
       # ui could be initialized with a delayed select spec so the choices and selected are NULL
       # here delayed are resolved
       isolate({
@@ -86,7 +88,7 @@ data_extract_single_srv <- function(id, datasets, single_data_extract_spec) {
           session = session,
           inputId = "select",
           choices = resolved$select$choices,
-          selected = resolved$select$selected
+          selected = shiny::restoreInput(ns("select"), resolved$select$selected)
         )
       })
 


### PR DESCRIPTION
Companion to https://github.com/insightsengineering/teal/pull/1011
Adds `shiny::restoreInput` calls to the `value`/`choices` arguments in `update*Input` calls.