### PR TITLE
Trigger the reactivity on input$vals when input$col is changed

### DIFF
--- a/R/data_extract_filter_module.R
+++ b/R/data_extract_filter_module.R
@@ -72,10 +72,11 @@ data_extract_filter_srv <- function(id, datasets, filter) {
         selected <- if (!is.null(filter$selected)) {
           filter$selected
         } else if (filter$multiple) {
-          restoreInput(ns("vals"), choices)
+          choices
         } else {
-          restoreInput(ns("vals"), choices[1L])
+          choices[1L]
         }
+        selected <- restoreInput(ns("vals"), selected)
         list(choices = choices, selected = selected)
       })
 

--- a/R/data_extract_filter_module.R
+++ b/R/data_extract_filter_module.R
@@ -61,9 +61,8 @@ data_extract_filter_srv <- function(id, datasets, filter) {
         )
       })
 
-      output$html_vals_container <- renderUI({
+      vals_options <- reactive({
         req(input$col)
-
         choices <- value_choices(
           data = datasets[[filter$dataname]](),
           var_choices = input$col,
@@ -77,14 +76,35 @@ data_extract_filter_srv <- function(id, datasets, filter) {
         } else {
           choices[1L]
         }
+        list(choices = choices, selected = selected)
+      })
 
+      output$html_vals_container <- renderUI({
         teal.widgets::optionalSelectInput(
           inputId = ns("vals"),
           label = filter$label,
-          choices = choices,
-          selected = selected,
+          choices = vals_options()$choices,
+          selected = vals_options()$selected,
           multiple = filter$multiple,
           fixed = filter$fixed
+        )
+      })
+
+      # Since we want the input$vals to depend on input$col for downstream calculations,
+      # we trigger reactivity by reassigning them. Otherwise, when input$col is changed without
+      # a change in input$val, the downstream computations will not be triggered.
+      observeEvent(input$col, {
+        teal.widgets::updateOptionalSelectInput(
+          session = session,
+          inputId = "vals",
+          choices = "",
+          selected = ""
+        )
+        teal.widgets::updateOptionalSelectInput(
+          session = session,
+          inputId = "vals",
+          choices = vals_options()$choices,
+          selected = vals_options()$selected
         )
       })
     }

--- a/R/data_extract_filter_module.R
+++ b/R/data_extract_filter_module.R
@@ -72,9 +72,9 @@ data_extract_filter_srv <- function(id, datasets, filter) {
         selected <- if (!is.null(filter$selected)) {
           filter$selected
         } else if (filter$multiple) {
-          choices
+          restoreInput(ns("vals"), choices)
         } else {
-          choices[1L]
+          restoreInput(ns("vals"), choices[1L])
         }
         list(choices = choices, selected = selected)
       })


### PR DESCRIPTION
Part of the PR #207 

Triggering the reactivity using `observeEvent`

Example to test:

```r
pkgload::load_all("../teal.modules.general")
pkgload::load_all("../teal.transform")
pkgload::load_all("../teal")
pkgload::load_all("../teal.widgets")

data <- teal_data()
data <- within(data, {
  require(nestcolor)
  ADSL <- rADSL
  ADSL$SEX2 <- rADSL$SEX
})
datanames(data) <- "ADSL"
join_keys(data) <- default_cdisc_join_keys[datanames(data)]

app <- init(
  data = data,
  modules = modules(
    tm_g_association(
      ref = data_extract_spec(
        dataname = "ADSL",
        filter = filter_spec(vars = choices_selected(variable_choices("ADSL"), "SEX")),
        select = select_spec(
          label = "Select variable:",
          choices = variable_choices(
            data[["ADSL"]],
            c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
          ),
          selected = "RACE",
          fixed = FALSE
        )
      ),
      vars = data_extract_spec(
        dataname = "ADSL",
        select = select_spec(
          label = "Select variables:",
          choices = variable_choices(
            data[["ADSL"]],
            c("SEX", "RACE", "COUNTRY", "ARM", "STRATA1", "STRATA2", "ITTFL", "BMRKR2")
          ),
          selected = "BMRKR2",
          multiple = TRUE,
          fixed = FALSE
        )
      ),
      ggplot2_args = ggplot2_args(
        labs = list(subtitle = "Plot generated by Association Module")
      )
    )
  )
)

shinyApp(app$ui, app$server)
```