### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     tidyselect
 Suggests:
     knitr (>= 1.42),
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     teal.code (>= 0.5.0),
     testthat (>= 3.1.5),
     withr (>= 2.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     stats,
     teal.data (>= 0.5.0),
     teal.logger (>= 0.1.3.9013),
-    teal.widgets (>= 0.4.0),
+    teal.widgets (>= 0.4.2),
     tidyr (>= 0.8.3),
     tidyselect
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     rlang (>= 1.0.0),
     shiny (>= 1.6.0),
     shinyjs,
-    shinyvalidate,
+    shinyvalidate (>= 0.1.3),
     stats,
     teal.data (>= 0.5.0),
     teal.logger (>= 0.1.3.9013),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     teal.data (>= 0.5.0),
     teal.logger (>= 0.1.3.9013),
     teal.widgets (>= 0.4.2),
-    tidyr (>= 0.8.3),
+    tidyr (>= 1.0.0),
     tidyselect
 Suggests:
     knitr (>= 1.42),


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.