### PR TITLE
log_trace -> log_debug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/data_extract_filter_module.R
+++ b/R/data_extract_filter_module.R
@@ -64,7 +64,7 @@ data_extract_filter_srv <- function(id, datasets, filter) {
       # We force the evaluation of filter, otherwise the observers are set up with the last element
       # of the list in data_extract_single_srv and not all of them (due to R lazy evaluation)
       force(filter)
-      logger::log_trace("data_extract_filter_srv initialized with: { filter$dataname } dataset.")
+      logger::log_debug("data_extract_filter_srv initialized with: { filter$dataname } dataset.")
 
       isolate({
         # when the filter is initialized with a delayed spec, the choices and selected are NULL
@@ -108,7 +108,7 @@ data_extract_filter_srv <- function(id, datasets, filter) {
           }
           dn <- filter$dataname
           fc <- paste(input$col, collapse = ", ")
-          logger::log_trace("data_extract_filter_srv@1 filter dataset: { dn }; filter var: { fc }.")
+          logger::log_debug("data_extract_filter_srv@1 filter dataset: { dn }; filter var: { fc }.")
           # In order to force reactivity we run two updates: (i) set up dummy values (ii) set up appropriate values
           # It's due to a missing reactivity triggers if new selected value is identical with previously selected one.
           teal.widgets::updateOptionalSelectInput(

--- a/R/data_extract_module.R
+++ b/R/data_extract_module.R
@@ -409,7 +409,7 @@ data_extract_srv.FilteredData <- function(id, datasets, data_extract_spec, ...) 
   moduleServer(
     id,
     function(input, output, session) {
-      logger::log_trace(
+      logger::log_debug(
         "data_extract_srv.FilteredData initialized with datasets: { paste(datasets$datanames(), collapse = ', ') }."
       )
 
@@ -472,7 +472,7 @@ data_extract_srv.list <- function(id,
   moduleServer(
     id,
     function(input, output, session) {
-      logger::log_trace(
+      logger::log_debug(
         "data_extract_srv.list initialized with datasets: { paste(names(datasets), collapse = ', ') }."
       )
 
@@ -696,7 +696,7 @@ data_extract_multiple_srv.reactive <- function(data_extract, datasets, ...) {
 #'
 data_extract_multiple_srv.FilteredData <- function(data_extract, datasets, ...) {
   checkmate::assert_class(datasets, classes = "FilteredData")
-  logger::log_trace(
+  logger::log_debug(
     "data_extract_multiple_srv.filteredData initialized with dataset: { paste(datasets$datanames(), collapse = ', ') }."
   )
 
@@ -759,7 +759,7 @@ data_extract_multiple_srv.list <- function(data_extract,
     checkmate::check_list(dataset_validation_rule, types = c("function", "formula", "NULL"), null.ok = TRUE)
   )
 
-  logger::log_trace(
+  logger::log_debug(
     "data_extract_multiple_srv.list initialized with dataset: { paste(names(datasets), collapse = ', ') }."
   )
 

--- a/R/data_extract_read_module.R
+++ b/R/data_extract_read_module.R
@@ -21,7 +21,7 @@ data_extract_read_srv <- function(id, datasets, single_data_extract_spec, iv, se
   moduleServer(
     id,
     function(input, output, session) {
-      logger::log_trace(
+      logger::log_debug(
         "data_extract_read_srv initialized with: { single_data_extract_spec$dataname } dataset."
       )
       filter_idx <- seq_along(single_data_extract_spec$filter)
@@ -49,7 +49,7 @@ data_extract_read_srv <- function(id, datasets, single_data_extract_spec, iv, se
         dn <- single_data_extract_spec$dataname
         cols <- `if`(length(input_col) > 0, paste(input_col, collapse = ", "), "NULL")
         sel <- `if`(length(selected) > 0, paste(selected, collapse = ", "), "NULL")
-        logger::log_trace("data_extract_read_srv@1 dataname: { dn }; filter vars: { cols }; filter values: { sel }")
+        logger::log_debug("data_extract_read_srv@1 dataname: { dn }; filter vars: { cols }; filter values: { sel }")
 
         list(
           columns = input_col,
@@ -142,7 +142,7 @@ data_extract_read_srv <- function(id, datasets, single_data_extract_spec, iv, se
 
           dn <- single_data_extract_spec$dataname
           sel <- `if`(length(res) > 0, paste(res, collapse = ", "), "NULL")
-          logger::log_trace("data_extract_read_srv@2 dataname: { dn }; select: { sel }.")
+          logger::log_debug("data_extract_read_srv@2 dataname: { dn }; select: { sel }.")
 
           res
         }
@@ -157,7 +157,7 @@ data_extract_read_srv <- function(id, datasets, single_data_extract_spec, iv, se
 
         dn <- single_data_extract_spec$dataname
         resh <- paste(res, collapse = ", ")
-        logger::log_trace("data_extract_read_srv@3 dataname: { dn }; reshape: { resh }.")
+        logger::log_debug("data_extract_read_srv@3 dataname: { dn }; reshape: { resh }.")
 
         res
       })

--- a/R/data_extract_single_module.R
+++ b/R/data_extract_single_module.R
@@ -76,7 +76,7 @@ data_extract_single_srv <- function(id, datasets, single_data_extract_spec) {
   moduleServer(
     id,
     function(input, output, session) {
-      logger::log_trace("data_extract_single_srv initialized with dataset: { single_data_extract_spec$dataname }.")
+      logger::log_debug("data_extract_single_srv initialized with dataset: { single_data_extract_spec$dataname }.")
 
       # ui could be initialized with a delayed select spec so the choices and selected are NULL
       # here delayed are resolved

--- a/R/get_dplyr_call.R
+++ b/R/get_dplyr_call.R
@@ -11,7 +11,7 @@
 #' @keywords internal
 #'
 get_dplyr_call_data <- function(selector_list, join_keys = teal.data::join_keys()) {
-  logger::log_trace("get_dplyr_call_data called with: { paste(names(selector_list), collapse = ', ') } selectors.")
+  logger::log_debug("get_dplyr_call_data called with: { paste(names(selector_list), collapse = ', ') } selectors.")
   checkmate::assert_class(join_keys, "join_keys")
   lapply(selector_list, check_selector)
 
@@ -137,7 +137,7 @@ get_dplyr_call <- function(selector_list,
                            join_keys = teal.data::join_keys(),
                            dplyr_call_data = get_dplyr_call_data(selector_list, join_keys = join_keys),
                            datasets = NULL) {
-  logger::log_trace(
+  logger::log_debug(
     paste(
       "get_dplyr_call called with:",
       "{ paste(names(datasets), collapse = ', ') } datasets;",
@@ -183,7 +183,7 @@ get_dplyr_call <- function(selector_list,
 #' @keywords internal
 #'
 get_select_call <- function(select) {
-  logger::log_trace("get_select_call called with: { paste(select, collapse = ', ') } columns.")
+  logger::log_debug("get_select_call called with: { paste(select, collapse = ', ') } columns.")
   if (is.null(select) || length(select) == 0) {
     return(NULL)
   }
@@ -204,7 +204,7 @@ get_select_call <- function(select) {
 #' @keywords internal
 #'
 get_filter_call <- function(filter, dataname = NULL, datasets = NULL) {
-  logger::log_trace(
+  logger::log_debug(
     paste(
       "get_filter_call called with:",
       "{ dataname } dataset;",
@@ -343,7 +343,7 @@ get_rename_call <- function(selector_list = list(),
                             dplyr_call_data = get_dplyr_call_data(selector_list, join_keys = join_keys)) {
   checkmate::assert_integer(idx, len = 1, any.missing = FALSE)
   stopifnot(length(dplyr_call_data) >= idx)
-  logger::log_trace(
+  logger::log_debug(
     paste(
       "get_rename_call called with:",
       "{ dplyr_call_data[[idx]]$internal_id } selector;",
@@ -379,7 +379,7 @@ get_reshape_call <- function(selector_list = list(),
                              dplyr_call_data = get_dplyr_call_data(selector_list, join_keys = join_keys)) {
   checkmate::assert_integer(idx, len = 1, any.missing = FALSE)
   stopifnot(length(dplyr_call_data) >= idx)
-  logger::log_trace(
+  logger::log_debug(
     paste(
       "get_reshape_call called with:",
       "{ dplyr_call_data[[idx]]$internal_id } selector;",
@@ -431,7 +431,7 @@ get_reshape_call <- function(selector_list = list(),
 #' @keywords internal
 #'
 get_pivot_longer_col <- function(selector) {
-  logger::log_trace("get_reshape_unite_col called with: { selector$internal_id } selector.")
+  logger::log_debug("get_reshape_unite_col called with: { selector$internal_id } selector.")
   setdiff(selector$select, selector$keys)
 }
 
@@ -447,7 +447,7 @@ get_pivot_longer_col <- function(selector) {
 #' @keywords internal
 #'
 get_reshape_unite_col <- function(selector) {
-  logger::log_trace("get_reshape_unite_col called with: { selector$internal_id } selector.")
+  logger::log_debug("get_reshape_unite_col called with: { selector$internal_id } selector.")
   intersect(
     selector$keys,
     unlist(lapply(selector$filters, `[[`, "columns"))
@@ -465,7 +465,7 @@ get_reshape_unite_col <- function(selector) {
 #' @keywords internal
 #'
 get_reshape_unite_vals <- function(selector) {
-  logger::log_trace("get_reshape_unite_vals called with: { selector$internal_id } selector.")
+  logger::log_debug("get_reshape_unite_vals called with: { selector$internal_id } selector.")
   unite_cols <- get_reshape_unite_col(selector)
   filters <- selector$filters
   filters_columns <- lapply(filters, `[[`, "columns")

--- a/R/get_merge_call.R
+++ b/R/get_merge_call.R
@@ -22,14 +22,14 @@ get_merge_call <- function(selector_list,
   if (!missing(selector_list)) {
     checkmate::assert_list(selector_list, min.len = 1)
     lapply(selector_list, check_selector)
-    logger::log_trace(
+    logger::log_debug(
       paste(
         "get_merge_call called with: { paste(names(selector_list), collapse = ', ') } selectors;",
         "{ merge_function } merge function."
       )
     )
   } else {
-    logger::log_trace(
+    logger::log_debug(
       paste(
         "get_merge_call called with:",
         "{ paste(sapply(dplyr_call_data, `[[`, 'internal_id'), collapse = ', ') } selectors;",
@@ -125,7 +125,7 @@ get_merge_call <- function(selector_list,
 #' @keywords internal
 #'
 get_merge_key_grid <- function(selector_list, join_keys = teal.data::join_keys()) {
-  logger::log_trace(
+  logger::log_debug(
     "get_merge_key_grid called with: { paste(names(selector_list), collapse = ', ') } selectors."
   )
 
@@ -168,7 +168,7 @@ get_merge_key_grid <- function(selector_list, join_keys = teal.data::join_keys()
 #' @keywords internal
 #'
 get_merge_key_pair <- function(selector_from, selector_to, key_from) {
-  logger::log_trace(
+  logger::log_debug(
     paste(
       "get_merge_key_pair called with:",
       "{ paste(selector_from$internal_id, selector_to$internal_id, sep = ', ') } selectors;",
@@ -195,7 +195,7 @@ get_merge_key_pair <- function(selector_from, selector_to, key_from) {
   } else {
     key_from
   }
-  logger::log_trace("get_merge_key_pair returns { paste(res, collapse = ', ') } merge keys.")
+  logger::log_debug("get_merge_key_pair returns { paste(res, collapse = ', ') } merge keys.")
   res
 }
 
@@ -215,7 +215,7 @@ get_merge_key_i <- function(selector_list, idx, dplyr_call_data = get_dplyr_call
     checkmate::assert_list(selector_list, min.len = 1)
     lapply(selector_list, check_selector)
 
-    logger::log_trace(
+    logger::log_debug(
       paste(
         "get_merge_key_i called with:",
         "{ paste(names(selector_list), collapse = ', ') } selectors;",
@@ -223,7 +223,7 @@ get_merge_key_i <- function(selector_list, idx, dplyr_call_data = get_dplyr_call
       )
     )
   } else {
-    logger::log_trace(
+    logger::log_debug(
       paste(
         "get_merge_key_i called with",
         "{ paste(sapply(dplyr_call_data, `[[`, 'internal_id'), collapse = ', ') } selectors;",
@@ -286,7 +286,7 @@ get_merge_key_i <- function(selector_list, idx, dplyr_call_data = get_dplyr_call
   }
 
   keys_map <- unique(keys_map)
-  logger::log_trace("get_merge_key_i returns { paste(keys_map, collapse = ' ') } unique keys.")
+  logger::log_debug("get_merge_key_i returns { paste(keys_map, collapse = ' ') } unique keys.")
   keys_map
 }
 
@@ -304,7 +304,7 @@ parse_merge_key_i <- function(selector_list,
                               idx,
                               dplyr_call_data = get_dplyr_call_data(selector_list),
                               merge_key = get_merge_key_i(selector_list, idx, dplyr_call_data)) {
-  logger::log_trace("parse_merge_key_i called with { paste(merge_key, collapse = ' ') } keys.")
+  logger::log_debug("parse_merge_key_i called with { paste(merge_key, collapse = ' ') } keys.")
   as.call(
     append(
       quote(c),
@@ -332,7 +332,7 @@ parse_merge_key_i <- function(selector_list,
 #' @keywords internal
 #'
 get_dropped_filters <- function(selector) {
-  logger::log_trace("get_dropped_filters called with { selector$internal_id } selector.")
+  logger::log_debug("get_dropped_filters called with { selector$internal_id } selector.")
   unlist(
     lapply(selector$filters, function(x) {
       if (isFALSE(x$drop_keys)) {
@@ -362,7 +362,7 @@ get_dropped_filters <- function(selector) {
 #'
 #' @export
 get_anl_relabel_call <- function(columns_source, datasets, anl_name = "ANL") {
-  logger::log_trace(
+  logger::log_debug(
     paste(
       "get_anl_relabel_call called with:",
       "{ paste(names(columns_source), collapse = ', ') } columns_source;",
@@ -448,7 +448,7 @@ get_anl_relabel_call <- function(columns_source, datasets, anl_name = "ANL") {
 #' )
 #' @export
 get_relabel_call <- function(labels) {
-  logger::log_trace("get_relabel_call called with: { paste(labels, collapse = ' ' ) } labels.")
+  logger::log_debug("get_relabel_call called with: { paste(labels, collapse = ' ' ) } labels.")
   if (length(stats::na.omit(labels)) == 0 || is.null(names(labels))) {
     return(NULL)
   }
@@ -475,7 +475,7 @@ get_relabel_call <- function(labels) {
 #' @keywords internal
 #'
 get_relabel_cols <- function(columns_source, dplyr_call_data) {
-  logger::log_trace(
+  logger::log_debug(
     "get_relabel_cols called with: { paste(names(columns_source), collapse = ', ') } columns_source."
   )
   pivot_longer_cols <- unlist(unname(lapply(dplyr_call_data, function(x) x[["pivot_longer_cols_renamed"]])))

--- a/R/merge_datasets.R
+++ b/R/merge_datasets.R
@@ -85,7 +85,7 @@
 #' @export
 #'
 merge_datasets <- function(selector_list, datasets, join_keys, merge_function = "dplyr::full_join", anl_name = "ANL") {
-  logger::log_trace(
+  logger::log_debug(
     paste(
       "merge_datasets called with:",
       "{ paste(names(datasets), collapse = ', ') } datasets;",
@@ -167,7 +167,7 @@ merge_datasets <- function(selector_list, datasets, join_keys, merge_function = 
     keys = keys,
     filter_info = filter_info
   )
-  logger::log_trace("merge_datasets merge code executed resulting in { anl_name } dataset.")
+  logger::log_debug("merge_datasets merge code executed resulting in { anl_name } dataset.")
   res
 }
 
@@ -181,7 +181,7 @@ merge_datasets <- function(selector_list, datasets, join_keys, merge_function = 
 #' @keywords internal
 #'
 merge_selectors <- function(selector_list) {
-  logger::log_trace("merge_selectors called with: { paste(names(selector_list), collapse = ', ') } selectors.")
+  logger::log_debug("merge_selectors called with: { paste(names(selector_list), collapse = ', ') } selectors.")
   checkmate::assert_list(selector_list, min.len = 1)
   lapply(selector_list, check_selector)
 

--- a/R/merge_expression_module.R
+++ b/R/merge_expression_module.R
@@ -175,7 +175,7 @@ merge_expression_module.list <- function(datasets,
                                          merge_function = "dplyr::full_join",
                                          anl_name = "ANL",
                                          id = "merge_id") {
-  logger::log_trace("merge_expression_module called with: { paste(names(datasets), collapse = ', ') } datasets.")
+  logger::log_debug("merge_expression_module called with: { paste(names(datasets), collapse = ', ') } datasets.")
   checkmate::assert_list(datasets, names = "named")
   checkmate::assert_list(data_extract, names = "named", types = c("list", "data_extract_spec", "NULL"))
   checkmate::assert_class(join_keys, "join_keys")
@@ -384,7 +384,7 @@ merge_expression_srv.list <- function(id = "merge_id",
   moduleServer(
     id,
     function(input, output, session) {
-      logger::log_trace(
+      logger::log_debug(
         "merge_expression_srv initialized with: { paste(names(datasets), collapse = ', ') } datasets."
       )
 


### PR DESCRIPTION
replace `log_trace` -> `log_debug` to separate `log_shiny_input_change` from our logs.