### PR TITLE
`teal.data::datanames()` is deprecated in favor of dot-prefix and `ls()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     shinyjs,
     shinyvalidate (>= 0.1.3),
     stats,
-    teal.data (>= 0.5.0),
+    teal.data (>= 0.6.0.9015),
     teal.logger (>= 0.1.3.9013),
     teal.widgets (>= 0.4.2),
     tidyr (>= 1.0.0),

--- a/R/utils.R
+++ b/R/utils.R
@@ -177,7 +177,7 @@ convert_teal_data <- function(datasets) {
     })
   } else if (is.reactive(datasets) && inherits(isolate(datasets()), "teal_data")) {
     sapply(
-      isolate(teal.data::datanames(datasets())),
+      isolate(ls(datasets())),
       function(dataname) {
         reactive(datasets()[[dataname]])
       },

--- a/R/utils.R
+++ b/R/utils.R
@@ -177,7 +177,7 @@ convert_teal_data <- function(datasets) {
     })
   } else if (is.reactive(datasets) && inherits(isolate(datasets()), "teal_data")) {
     sapply(
-      isolate(ls(datasets())),
+      isolate(names(datasets())),
       function(dataname) {
         reactive(datasets()[[dataname]])
       },


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/teal.data/issues/333

Blocked by:

- https://github.com/insightsengineering/teal.code/pull/218
- https://github.com/insightsengineering/teal.data/pull/347
