### PR TITLE
Remove lookup-refs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -41,13 +41,6 @@ jobs:
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -69,13 +62,6 @@ jobs:
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
@@ -85,13 +71,6 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️
@@ -104,13 +83,6 @@ jobs:
     with:
       auto-update: true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,10 +43,3 @@ jobs:
       default-landing-page: latest-tag
       additional-unit-test-report-directories: unit-test-report-non-cran
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,6 @@ jobs:
     with:
       default-landing-page: latest-tag
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   validation:
     name: R Package Validation report 📃
     needs: release
@@ -32,13 +25,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   release:
     name: Create release 🎉
     uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main
@@ -64,13 +50,6 @@ jobs:
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   coverage:
     name: Coverage 📔
     needs: [release, docs]
@@ -81,13 +60,6 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   wasm:
     name: Build WASM packages 🧑‍🏭
     needs: release

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -56,14 +56,6 @@ jobs:
       )
     name: revdepcheck ↩️
     uses: insightsengineering/r.pkg.template/.github/workflows/revdepcheck.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/formatters
-        insightsengineering/rtables
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -72,11 +64,3 @@ jobs:
       )
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.widgets
-        insightsengineering/teal.code
-        insightsengineering/formatters
-        insightsengineering/rtables


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/609

From now on, we will provide development dependencies in 
```
Remotes: repo/project@branch
```
format, so it's explicitly visible in the DESCRIPTION file and can be handled by `pak::install`, `renv::install` and `remotes::install`.

With development dependencies specified in CJ Pipelines configuration, this connection was hidden, and it was hard to install the package from the main branch (or any other branch) locally from user's machine.