### PR TITLE
chore: bump teal.logger dependency to 0.4.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     shinyvalidate (>= 0.1.3),
     stats,
     teal.data (>= 0.7.0),
-    teal.logger (>= 0.3.1),
+    teal.logger (>= 0.4.0),
     teal.widgets (>= 0.4.3),
     tidyr (>= 1.0.0),
     tidyselect (>= 1.2.1),


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.logger (>= 0.4.0) and removes it from Remotes.